### PR TITLE
ccache within CMake

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 # Language selection
 language: python
 
+cache: ccache
+
 # Currently commented out as set with environment flags
 # Both clang and gcc can be tested. The more is the better.
 #compiler:
@@ -72,6 +74,7 @@ addons:
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew tap homebrew/science; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install ccache; fi
   - # Note: boost is already installed on osx on travis so should not be included. However, we currently need boost-python
   - # if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install boost-python; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install ace; fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,12 @@ include(version_config.cmake)
 include(ExternalProject)
 include(ExternalProjectDependency)
 
+# enable ccache https://ccache.samba.org/
+find_program(CCACHE_PROGRAM ccache)
+if(CCACHE_PROGRAM)
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")
+endif()
+
 set(PRIMARY_PROJECT_NAME CCPPETMR)
 option(${PRIMARY_PROJECT_NAME}_SUPERBUILD "Build ${PRIMARY_PROJECT_NAME} and the projects it depends on via SuperBuild.cmake." ON)
 


### PR DESCRIPTION
according to what I've read, this should have speeded-up a rebuild on Travis (at least on Linux), but timing was virtually the same. I haven't tried this locally yet.

I wonder if it doesn't work because because `language` is `Python` in `.travis.yml`.

See also https://docs.travis-ci.com/user/caching/