### PR TITLE
docker: separate gadgetron

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -251,7 +251,7 @@ install:
         else
           mv ~/.ccache devel/
         fi
-        $DCC build --pull core
+        $DCC build --pull core gadgetron
         # don't count the extra clone we're about to do
         # TODO: Do we need this? Is docker a distinct cloner from travis?
         # cloners_count_decrement
@@ -278,6 +278,7 @@ script:
     if [[ -n "$DOCKER_BUILD" ]]; then
       # push images - but only after tests pass within the container!
       echo "$DOCKER_PWD" | docker login -u $DOCKER_USR --password-stdin
+      $DCC up -d gadgetron
       $DCC run --rm sirf /bin/bash --login -c '/devel/test.sh 1' \
         && $DCC push \
         && if [[ -n "$TRAVIS_TAG" && "$DOCKER_BUILD" != DEVEL ]]; then ( set -ev
@@ -286,7 +287,14 @@ script:
              docker tag ccppetmr/sirf:latest ccppetmr/sirf:release
              docker push ccppetmr/sirf:"$TRAVIS_TAG"
              docker push ccppetmr/sirf:release
-           ); fi
+           ); fi \
+        && (
+          # print for debugging
+          echo "----------- Last 70 lines of gadgetron.log"
+          wget -t1 --timeout 5 http://localhost:9001/logtail/gadgetron -O - 2>/dev/null | tail -n 70
+          # the above is expected to exit non-zero after timeout
+          $DCC stop
+        )
     else
       ./INSTALL/bin/gadgetron >& gadgetron.log&
       # print for debugging

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,11 +30,6 @@ COPY build_python-ubuntu.sh .
 RUN bash build_python-ubuntu.sh
 RUN rm build_python-ubuntu.sh
 
-# Gadgetron
-COPY build_gadgetron-ubuntu.sh .
-RUN bash build_gadgetron-ubuntu.sh
-RUN rm build_gadgetron-ubuntu.sh
-
 # SIRF external deps
 COPY build_system-ubuntu.sh .
 RUN bash build_system-ubuntu.sh
@@ -77,6 +72,7 @@ COPY devel/.ccache/ /opt/ccache/
 RUN ccache -o cache_dir=/opt/ccache
 ARG BUILD_FLAGS="\
  -DCMAKE_BUILD_TYPE=Release\
+ -DBUILD_GADGETRON=OFF\
  -DBUILD_STIR_WITH_OPENMP=ON -DUSE_SYSTEM_ACE=ON\
  -DUSE_SYSTEM_Armadillo=ON -DUSE_SYSTEM_Boost=ON -DUSE_SYSTEM_FFTW3=ON\
  -DUSE_SYSTEM_HDF5=ON -DUSE_ITK=ON -DBUILD_siemens_to_ismrmrd=ON\

--- a/docker/devel/test.sh
+++ b/docker/devel/test.sh
@@ -18,6 +18,13 @@ pushd $SIRF_PATH/../..
 GCONFIG=./INSTALL/share/gadgetron/config/gadgetron.xml
 [ -f "$GCONFIG" ] || cp "$GCONFIG".example "$GCONFIG"
 [ -f ./INSTALL/bin/gadgetron ] && ./INSTALL/bin/gadgetron >& gadgetron.log&
+#sudo sysctl net.ipv4.ip_forward=1
+#sudo apt install -yqq iptables
+#sudo iptables -t nat -A PREROUTING -p tcp --dport 9002 -j DNAT --to-destination 172.18.0.2:9002
+#sudo iptables -t nat -A POSTROUTING -j MASQUERADE
+pushd $SIRF_PATH/src/xGadgetron/pGadgetron/tests
+python test_all.py
+popd
 
 ctest -VV
 ret=$?

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -20,10 +20,9 @@ services:
   tty: true
   # cap_add:
   #  - NET_ADMIN
-  #TODO: uncomment for external gadgetron
-  # network_mode: "host"  # host only works on linux: https://docs.docker.com/network/host/
-  # depends_on:
-  #  - gadgetron
+  network_mode: "host"  # host only works on linux: https://docs.docker.com/network/host/
+  depends_on:
+   - gadgetron
   volumes:
    - ./devel:/devel
  core:


### PR DESCRIPTION
- [x] fix #206
- [ ] build & host our own `gadgetron` image which isn't bloated?
  + [gadgetron/gadgetron/docker/base/ubuntu_1804/Dockerfile](https://github.com/gadgetron/gadgetron/blob/master/docker/base/ubuntu_1804/Dockerfile)
  + [gadgetron/gadgetron/docker/incremental/ubuntu_1804_no_cuda/Dockerfile](https://github.com/gadgetron/gadgetron/blob/master/docker/incremental/ubuntu_1804_no_cuda/Dockerfile)
- [ ] windows support (depends on https://github.com/CCPPETMR/SIRF/issues/182)
  + `network_mode: "host"` only works on linux: https://docs.docker.com/network/host/
- [ ] provide images for both with (old) and without (this PR) `gadgetron`:
  + `sirf` and `sirf_nogadgetron` (my preference), or
  + `sirf_gadgetron` and `sirf`
- [ ] split `DOCKER_BUILD=1` into `gadgetron` and `nogadgetron`
- [ ] same with `DEVEL`
- [ ] update documentation