### PR TITLE
Switched to using Gadgetron 3.17.0 (fixes #305)

### DIFF
--- a/version_config.cmake
+++ b/version_config.cmake
@@ -128,7 +128,7 @@ set(DEFAULT_ISMRMRD_TAG v1.4.1)
 
 ## Gadgetron
 set(DEFAULT_Gadgetron_URL https://github.com/gadgetron/gadgetron )
-set(DEFAULT_Gadgetron_TAG v3.17.0))))))))
+set(DEFAULT_Gadgetron_TAG v3.17.0)
 #set(DEFAULT_Gadgetron_TAG b6191eaaa72ccca6c6a5fe4c0fa3319694f512ab)
 
 ## ASTRA

--- a/version_config.cmake
+++ b/version_config.cmake
@@ -128,7 +128,8 @@ set(DEFAULT_ISMRMRD_TAG v1.4.1)
 
 ## Gadgetron
 set(DEFAULT_Gadgetron_URL https://github.com/gadgetron/gadgetron )
-set(DEFAULT_Gadgetron_TAG b6191eaaa72ccca6c6a5fe4c0fa3319694f512ab)
+set(DEFAULT_Gadgetron_TAG v3.17.0))))))))
+#set(DEFAULT_Gadgetron_TAG b6191eaaa72ccca6c6a5fe4c0fa3319694f512ab)
 
 ## ASTRA
 set(DEFAULT_astra-toolbox_URL https://github.com/astra-toolbox/astra-toolbox )


### PR DESCRIPTION
Gadgetron 3.17.0 seems to build and run ok on VM, let us try it elsewhere now.