### PR TITLE
skip docker on PRs/non-master branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ cache:  # shared between builds
 stages:
 - test
 - docker-core
-- docker
+- name: docker
+  if: NOT type = pull_request
 
 # Currently commented out as set with environment flags
 # Both clang and gcc can be tested. More is the better.
@@ -328,6 +329,7 @@ jobs:
  - os: linux
    name: docker +DEVEL
    env: DOCKER_BUILD=DEVEL
+   if: branch = master
    services:
    - docker
    addons: *docker_addons


### PR DESCRIPTION
- TODO (later in a different PR if needed): ideally should really build docker using current SuperBuild commit
(instead of `-b master` in `docker/user_sirf-ubuntu.sh`) https://github.com/SyneRBI/SIRF-SuperBuild/pull/361#issuecomment-601102294
- fixes #332
- maybe fixes #398 (seems duplicate)?