### PR TITLE
Pass HDF5_ROOT through to projects

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 - Made ${proj}_SOURCE_DIR a cached variables such that the user can point to an existing directory.
 - Added support for passing CMAKE args to projects from the SuperBuild call.
 - Use macros to drastically simplify (and reduce size of) the External*.cmake files.
+- Pass HDF5_ROOT through to projects if it's defined and USE_SYSTEM_HDF5=ON
 - Added checking whether default SWIG executable exists.
 - Corrected logic around building SIRF and Registration.
 - Added JSON as external package.

--- a/SuperBuild/External_HDF5.cmake
+++ b/SuperBuild/External_HDF5.cmake
@@ -94,6 +94,9 @@ if(NOT ( DEFINED "USE_SYSTEM_${externalProjName}" AND "${USE_SYSTEM_${externalPr
          -DHDF5_LIBRARIES:STRING=${HDF5_LIBRARIES}
          -DHDF5_FIND_DEBUG:BOOL=ON
       )
+      if (HDF5_ROOT)
+        set(HDF5_CMAKE_ARGS ${HDF5_CMAKE_ARGS} -DHDF5_ROOT:PATH=${HDF5_ROOT})
+      endif()
   endif()
   ExternalProject_Add_Empty(${proj} DEPENDS "${${proj}_DEPENDENCIES}"
     ${${proj}_EP_ARGS_DIRS}


### PR DESCRIPTION
... if it's defined and `USE_SYSTEM_HDF5=ON`