### PR TITLE
disable STIR HDF5 support by default

### DIFF
--- a/SuperBuild/External_STIR.cmake
+++ b/SuperBuild/External_STIR.cmake
@@ -50,7 +50,7 @@ if(NOT ( DEFINED "USE_SYSTEM_${externalProjName}" AND "${USE_SYSTEM_${externalPr
   option(STIR_BUILD_SWIG_PYTHON "Build STIR Python interface" ${default_STIR_BUILD_SWIG_PYTHON})
   option(STIR_DISABLE_CERN_ROOT "Disable STIR ROOT interface" ON)
   option(STIR_DISABLE_LLN_MATRIX "Disable STIR Louvain-la-Neuve Matrix library for ECAT7 support" ON)
-  option(STIR_DISABLE_HDF5_SUPPORT "Disable STIR use of HDF5 libraries" OFF)
+  option(STIR_DISABLE_HDF5_SUPPORT "Disable STIR use of HDF5 libraries" ON)
   option(STIR_ENABLE_EXPERIMENTAL "Enable STIR experimental code" OFF)
 
   mark_as_advanced(BUILD_STIR_EXECUTABLES BUILD_STIR_SWIG_PYTHON STIR_DISABLE_CERN_ROOT)


### PR DESCRIPTION
By default, disable STIR's HDF5 support. Avoids this current problem - https://github.com/SyneRBI/SIRF/issues/685.