### PR TITLE
set preprocessor define BOOST_ERROR_CODE_HEADER_ONLY

### DIFF
--- a/SuperBuild/External_Boost.cmake
+++ b/SuperBuild/External_Boost.cmake
@@ -108,6 +108,14 @@ if(NOT ( DEFINED "USE_SYSTEM_${externalProjName}" AND "${USE_SYSTEM_${externalPr
   )
 endif()
 
+# Avoid linking problems with boost system, specifically 
+# boost::system::detail::generic_category_instance
+# by forcing Boost to use an inline variable, as opposed to
+# the instantiated variable in the library
+# See https://github.com/SyneRBI/SIRF-SuperBuild/issues/161
+set(Boost_CMAKE_ARGS ${Boost_CMAKE_ARGS}
+        -DCMAKE_CXX_FLAGS:STRING=-DBOOST_ERROR_CODE_HEADER_ONLY\ -DBOOST_SYSTEM_NO_DEPRECATED)
+
 mark_as_superbuild(
   VARS
     ${externalProjName}_DIR:PATH


### PR DESCRIPTION
We get linking problems with boost system if the C++ versions don't match (i.e. the one used to compile boost, and the current one), specifically with boost::system::detail::generic_category_instance

Setting this variable forces Boost to use an inline variable, as opposed to the instantiated variable in the library

Fixes https://github.com/SyneRBI/SIRF-SuperBuild/issues/161