### PR TITLE
force Armadillo libraries to be installed in lib

### DIFF
--- a/SuperBuild/External_Armadillo.cmake
+++ b/SuperBuild/External_Armadillo.cmake
@@ -71,6 +71,7 @@ if(NOT ( DEFINED "USE_SYSTEM_${externalProjName}" AND "${USE_SYSTEM_${externalPr
     CMAKE_ARGS
       -DCMAKE_PREFIX_PATH:PATH=${SUPERBUILD_INSTALL_DIR}
       -DCMAKE_INSTALL_PREFIX:PATH=${${proj}_INSTALL_DIR}
+      -DCMAKE_INSTALL_LIBDIR:PATH=${${proj}_INSTALL_DIR}/lib #force installation in lib (override GNUInstallDirs)
       -DDETECT_HDF5:BOOL=OFF
       ${CLANG_ARG}
   )


### PR DESCRIPTION
This override the GNUinstallation conventions, as none of the other packages uses this.

Fixes #430