### PR TITLE
Let STIR depend on nlohmann_json by default and fix

### DIFF
--- a/SuperBuild/External_STIR.cmake
+++ b/SuperBuild/External_STIR.cmake
@@ -71,8 +71,8 @@ if(NOT ( DEFINED "USE_SYSTEM_${externalProjName}" AND "${USE_SYSTEM_${externalPr
   if (USE_NiftyPET)
     list(APPEND ${proj}_DEPENDENCIES "NiftyPET")
   endif()
-  option(STIR_DISABLE_JSON "Disable JSON support in ${proj}" ON)
-  if (STIR_USE_JSON)
+  option(STIR_DISABLE_JSON "Disable JSON support in ${proj}" OFF)
+  if (NOT STIR_DISABLE_JSON)
     list(APPEND ${proj}_DEPENDENCIES "JSON")
   endif()
 


### PR DESCRIPTION
STIR v4.* has extra functionality for CTAC->mu if this library is available. We enable this now by default.

Also fix use of a related CMake variable (we were using `STIR_USE_JSON` while the option is `STIR_DISABLE_JSON`)