### PR TITLE
set JSON to 3.9.1 and don't build tests by defaults

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 # ChangeLog
 ## v#.#.#
 - Enabled HDF5 support for STIR by default (build C++ libraries for HDF5)
+- Add option BULD_TESTING_JSON (default OFF)
+- Updated versions:
+   - JSON: 3.9.1
 
 ## v2.2.0
 - Updated to reflect change from CCPPETMR to CCPSyneRBI.

--- a/SuperBuild/External_JSON.cmake
+++ b/SuperBuild/External_JSON.cmake
@@ -36,16 +36,24 @@ SetExternalProjectFlags(${proj})
 
 if(NOT ( DEFINED "USE_SYSTEM_${externalProjName}" AND "${USE_SYSTEM_${externalProjName}}" ) )
   message(STATUS "${__indent}Adding project ${proj}")
-
+  option(BUILD_TESTING_${proj} "Build tests for ${proj}" OFF)
   SetGitTagAndRepo("${proj}")
 
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}
     ${${proj}_EP_ARGS_GIT}
     ${${proj}_EP_ARGS_DIRS}
+    CMAKE_ARGS
+      -DJSON_BuildTests:BOOL=${BUILD_TESTING_${proj}}
+       ${${proj}_EXTRA_CMAKE_ARGS_LIST}
     DEPENDS ${${proj}_DEPENDENCIES}
   )
 
+  if (BUILD_TESTING_${proj})
+    add_test(NAME ${proj}_TESTS
+         COMMAND ${CMAKE_CTEST_COMMAND} -C $<CONFIGURATION> --output-on-failure
+         WORKING_DIRECTORY ${${proj}_BINARY_DIR})
+  endif()
 
   else()
     ExternalProject_Add_Empty(${proj} DEPENDS "${${proj}_DEPENDENCIES}"

--- a/version_config.cmake
+++ b/version_config.cmake
@@ -151,7 +151,7 @@ set(DEFAULT_SPM_URL https://github.com/spm/SPM12.git )
 set(DEFAULT_SPM_TAG r7771)
 
 set(DEFAULT_JSON_URL https://github.com/nlohmann/json.git )
-set(DEFAULT_JSON_TAG v3.7.3)
+set(DEFAULT_JSON_TAG v3.9.1)
 
 # CCPi CIL
 set(CIL_VERSION "v20.04")


### PR DESCRIPTION
In most cases, we don't need to build the tests, so make it an option BUILD_TESTING_JSON