### PR TITLE
work-around ISMRMRD compilation problem with Visual Studio

### DIFF
--- a/version_config.cmake
+++ b/version_config.cmake
@@ -123,8 +123,13 @@ set(DEFAULT_NIFTYREG_TAG 99d584e2b8ea0bffe7e65e40c8dc818751782d92 )
 set(DEFAULT_NIFTYREG_REQUIRED_VERSION 1.5.68)
 
 ## ISMRMRD
-set(DEFAULT_ISMRMRD_URL https://github.com/ismrmrd/ismrmrd )
-set(DEFAULT_ISMRMRD_TAG v1.4.1)
+if (WIN32)
+  set(DEFAULT_ISMRMRD_URL https://github.com/SyneRBI/ismrmrd )
+  set(DEFAULT_ISMRMRD_TAG program_options_fix)
+else()
+  set(DEFAULT_ISMRMRD_URL https://github.com/ismrmrd/ismrmrd )
+  set(DEFAULT_ISMRMRD_TAG v1.4.1)
+endif()
 
 ## Gadgetron
 set(DEFAULT_Gadgetron_URL https://github.com/gadgetron/gadgetron )


### PR DESCRIPTION
With Visual Studio, ISMRMRD utiliites have double-linking problems with boost program_options.
We therefore set the ISMRMRD version to a branch corresponding to
https://github.com/ismrmrd/ismrmrd/pull/134.
This branch is currently synced with 1.4.1 + one update. Ideally ISMRMRD merges the PR.

Fixes #403