### PR TITLE
removes py27 builds in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,7 @@ addons:
   - libboost-all-dev
   - libhdf5-serial-dev
   - libfftw3-dev
-  - python-dev
   - python3-dev
-  - python-tk
   - python3-tk
   - libopenblas-dev
   - libatlas-base-dev
@@ -110,29 +108,13 @@ jobs:
    name: py36 -boost +fftw3 +hdf5 +ace +cil
    env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_FFTW3=ON -DUSE_SYSTEM_HDF5=ON -DUSE_SYSTEM_ACE=ON -DBUILD_CIL=ON" PYMVER=3
  - os: linux
-   python: 2.7
-   name: py27 -boost +fftw3 +hdf5 +ace +cil
-   env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_FFTW3=ON -DUSE_SYSTEM_HDF5=ON -DUSE_SYSTEM_ACE=ON -DBUILD_CIL=ON" PYMVER=2
- - os: linux
-   python: 2.7
-   name: py27 -boost +fftw3 +hdf5 +ace +cil_lite
-   env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_FFTW3=ON -DUSE_SYSTEM_HDF5=ON -DUSE_SYSTEM_ACE=ON -DBUILD_CIL_LITE=ON" PYMVER=2
- - os: linux
    python: 3.6
    name: py36 -boost +fftw3 +hdf5 +ace +cil_lite
    env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_FFTW3=ON -DUSE_SYSTEM_HDF5=ON -DUSE_SYSTEM_ACE=ON -DBUILD_CIL_LITE=ON" PYMVER=3
  - os: linux
-   python: 2.7
-   name: py27 -boost +fftw3 +hdf5 +siemens_to_ismrmrd +swig +ace
-   env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_FFTW3=ON -DUSE_SYSTEM_HDF5=ON -DBUILD_siemens_to_ismrmrd=ON -DUSE_SYSTEM_SWIG=ON -DUSE_SYSTEM_ACE=ON" PYMVER=2
- - os: linux
    python: 3.6
    name: py36 +DEVEL -boost -hdf5 -fftw3 +ace +siemens_to_ismrmrd
    env: EXTRA_BUILD_FLAGS="-DDEVEL_BUILD=ON -DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_FFTW3=OFF -DUSE_SYSTEM_ACE=ON -DBUILD_siemens_to_ismrmrd=ON" PYMVER=3
- - os: linux
-   python: 2.7
-   name: py27 +DEVEL -boost -fftw3 -hdf5 -swig +ace
-   env: EXTRA_BUILD_FLAGS="-DDEVEL_BUILD=ON -DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_FFTW3=OFF -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_ACE=ON -DUSE_SYSTEM_SWIG=OFF" PYMVER=2
  # osx disabled due to https://github.com/SyneRBI/SIRF-SuperBuild/issues/450
  #- os: osx
  #  osx_image: xcode11.2


### PR DESCRIPTION
This removes Python 2.7 support from travis.

VM: https://github.com/SyneRBI/SyneRBI_VM/pull/170