### PR TITLE
do not build ITK_ReviewModule by default

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 ## v#.#.#
 - Environment files with name env_sirf.sh (and csh) are created. Symbolic links or copies with the previous name env_ccppetmr.sh (and csh) depending on the version of CMake available are made.
 - Enabled HDF5 support for STIR by default (build C++ libraries for HDF5)
+- Disabled building of `Module_ITKReview` by default
 - Fix some issues with finding Python [#472](https://github.com/SyneRBI/SIRF-SuperBuild/issues/472)
 - Add option `BUILD_TESTING_JSON` (default OFF)
 - Updated versions:

--- a/SuperBuild/External_ITK.cmake
+++ b/SuperBuild/External_ITK.cmake
@@ -52,11 +52,10 @@ if(NOT ( DEFINED "USE_SYSTEM_${externalProjName}" AND "${USE_SYSTEM_${externalPr
   OPTION(ITK_MINIMAL_LIBS "Only build ITK IO libraries" ON)
   if (ITK_MINIMAL_LIBS)
 
+    # -DModule_ITKReview:BOOL=ON # should be ON for PETPVC, but not for others
     set(ITK_CMAKE_FLAGS
       -DITK_BUILD_DEFAULT_MODULES:BOOL=OFF
       -DITKGroup_IO:BOOL=ON
-      -DITKGroup_IO:BOOL=ON
-      -DModule_ITKReview:BOOL=ON # for PETPVC
       )
   else()
 

--- a/docker/user_service-ubuntu.sh
+++ b/docker/user_service-ubuntu.sh
@@ -7,6 +7,7 @@ INSTALL_DIR="${1:-/opt}"
 git clone https://github.com/SyneRBI/SIRF-Exercises --recursive -b master $INSTALL_DIR/SIRF-Exercises
 
 if [ -f requirements-service.txt ]; then
+  echo "Installing jupyter via conda or pip"
   conda install -c conda-forge -y --file requirements-service.txt || \
   pip install -U -r requirements-service.txt
 fi


### PR DESCRIPTION
we don't need this module for STIR/SIRF.

Not building it increases chances of success with long paths on Windows