### PR TITLE
Patch Gadgetron include files for RPE encoding

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 # ChangeLog
 ## v#.#.#
+- Patch Gadgetron include file hoNDFFT.h to remove spurious ".."
 - Environment files with name env_sirf.sh (and csh) are created. Symbolic links or copies with the previous name env_ccppetmr.sh (and csh) depending on the version of CMake available are made.
 - Enabled HDF5 support for STIR by default (build C++ libraries for HDF5)
 - Fix some issues with finding Python [#472](https://github.com/SyneRBI/SIRF-SuperBuild/issues/472)

--- a/README.md
+++ b/README.md
@@ -104,6 +104,11 @@ cmake --build . --config Release
 
 Note that there is no separate install step.
 
+### Gadgetron include patch
+The installed Gadgetron include files contain some spurious `..` which prevent correct compilation of code with it. For this reason we patch the include file after it's installed. To patch we use Python as it is probably the most portable tool.
+
+The include has been fixed in more recent versions of Gadgetron and our patch should not do anything in such case.
+
 ### Example Gadgetron configuration file
 Gadgetron requires a configuration file. An example is supplied and, as a starting point, this can be copied and used as the real thing:
 ```

--- a/SuperBuild/External_Gadgetron.cmake
+++ b/SuperBuild/External_Gadgetron.cmake
@@ -112,6 +112,7 @@ if(NOT ( DEFINED "USE_SYSTEM_${externalProjName}" AND "${USE_SYSTEM_${externalPr
       -DUSE_OPENMP:BOOL=${${proj}_ENABLE_OPENMP}
     DEPENDS
         ${${proj}_DEPENDENCIES}
+    INSTALL_COMMAND ${CMAKE_COMMAND} --build . --target install &&  ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/patches/Gadgetron_include-patch.py ${SUPERBUILD_INSTALL_DIR}/include/gadgetron/hoNFFT.h ${SUPERBUILD_INSTALL_DIR}/include/gadgetron/hoNFFT.h
   )
 
     set(Gadgetron_ROOT        ${Gadgetron_SOURCE_DIR})

--- a/SuperBuild/External_Gadgetron.cmake
+++ b/SuperBuild/External_Gadgetron.cmake
@@ -83,6 +83,15 @@ if(NOT ( DEFINED "USE_SYSTEM_${externalProjName}" AND "${USE_SYSTEM_${externalPr
     set(${proj}_ENABLE_OPENMP OFF)
   endif()
 
+  # require to have access to Python for patching
+  if (NOT PYTHON_EXECUTABLE)
+    if (${CMAKE_VERSION} VERSION_LESS "3.12")
+      find_package(PythonInterp REQUIRED)
+    else()
+      find_package(Python COMPONENTS Interpreter REQUIRED)
+      set (PYTHON_EXECUTABLE ${Python_EXECUTABLE})
+    endif()
+  endif()
 
   # Sets ${proj}_URL_MODIFIED and ${proj}_TAG_MODIFIED
   SetGitTagAndRepo("${proj}")

--- a/patches/Gadgetron_include-patch.py
+++ b/patches/Gadgetron_include-patch.py
@@ -1,4 +1,21 @@
-from __future__ import print_function, division
+# This file is part of the CCP SyneRBI (formerly PETMR) Synergistic Image Reconstruction Framework (SIRF) SuperBuild.
+# Copyright 2021 Rutherford Appleton Laboratory STFC
+#
+# Author: Edoardo Pasca
+#
+# This is software developed for the Collaborative Computational
+# Project in Synergistic Reconstruction for Biomedical Imaging (formerly CCP PETMR)
+# (http://www.ccpsynerbi.ac.uk/).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#       http://www.apache.org/licenses/LICENSE-2.0
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
 import sys
 
 with open(sys.argv[1], 'r') as f:

--- a/patches/Gadgetron_include-patch.py
+++ b/patches/Gadgetron_include-patch.py
@@ -1,0 +1,9 @@
+from __future__ import print_function, division
+import sys
+
+with open(sys.argv[1], 'r') as f:
+    testdata = f.read()
+    updated = testdata.replace('../NFFT.h', "NFFT.h")
+    updated = updated.replace('../nfft_export.h', "nfft_export.h")
+with open(sys.argv[2], 'w') as fw:    
+    fw.write(updated)

--- a/patches/Gadgetron_include-patch.py
+++ b/patches/Gadgetron_include-patch.py
@@ -22,5 +22,5 @@ with open(sys.argv[1], 'r') as f:
     testdata = f.read()
     updated = testdata.replace('../NFFT.h', "NFFT.h")
     updated = updated.replace('../nfft_export.h', "nfft_export.h")
-with open(sys.argv[2], 'w') as fw:    
+with open(sys.argv[2], 'w') as fw:
     fw.write(updated)

--- a/patches/cil-patch.py
+++ b/patches/cil-patch.py
@@ -17,6 +17,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.import sys
 
+import sys
 with open(sys.argv[1], 'r') as f:
     testdata = f.read()
     updated = testdata.replace('sys.prefix', "os.environ['SIRF_INSTALL_PATH']")

--- a/patches/cil-patch.py
+++ b/patches/cil-patch.py
@@ -1,5 +1,21 @@
-from __future__ import print_function, division
-import sys
+# This file is part of the CCP SyneRBI (formerly PETMR) Synergistic Image Reconstruction Framework (SIRF) SuperBuild.
+# Copyright 2020 - 2021 Rutherford Appleton Laboratory STFC
+#
+# Author: Edoardo Pasca
+#
+# This is software developed for the Collaborative Computational
+# Project in Synergistic Reconstruction for Biomedical Imaging (formerly CCP PETMR)
+# (http://www.ccpsynerbi.ac.uk/).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#       http://www.apache.org/licenses/LICENSE-2.0
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.import sys
 
 with open(sys.argv[1], 'r') as f:
     testdata = f.read()


### PR DESCRIPTION
Applies a patch to the installed Gadgetron include file `hoNFFT.h` that creates a compiler error in @johannesmayer [RPE-encoding](https://github.com/johannesmayer/SIRF/tree/rpe-encoding) branch.