### PR TITLE
Add external projects to mark as advanced

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@
 - Updated versions:
    - JSON: 3.9.1
    - SWIG: 4.0.2
-   - SIRF: 933630ece93ded99dffbdc60e4eef993051621b1
+   - SIRF: ba1af302970cbe0042a3e47ad81060309854055a
 ## v2.2.0
 - Updated to reflect change from CCPPETMR to CCPSyneRBI.
 - Made ${proj}_SOURCE_DIR a cached variables such that the user can point to an existing directory.

--- a/version_config.cmake
+++ b/version_config.cmake
@@ -196,7 +196,7 @@ if (DEVEL_BUILD)
 else()
   # version 2.2.0 has a bug in algebra leading to failure of SIRF CIL TESTS
   # which are fixed in master
-  set(DEFAULT_SIRF_TAG 933630ece93ded99dffbdc60e4eef993051621b1)
+  set(DEFAULT_SIRF_TAG ba1af302970cbe0042a3e47ad81060309854055a)
 
   ## STIR
   set(DEFAULT_STIR_URL https://github.com/UCL/STIR )

--- a/version_config.cmake
+++ b/version_config.cmake
@@ -251,8 +251,6 @@ set(CCPi-Regularisation-Toolkit_URL ${DEFAULT_CCPi-Regularisation-Toolkit_URL} C
 set(CCPi-Regularisation-Toolkit_TAG ${DEFAULT_CCPi-Regularisation-Toolkit_TAG} CACHE STRING ON)
 set(CCPi-Framework_URL ${DEFAULT_CCPi-Framework_URL} CACHE STRING ON)
 set(CCPi-Framework_TAG ${DEFAULT_CCPi-Framework_TAG} CACHE STRING ON)
-set(CCPi-FrameworkPlugins_URL ${DEFAULT_CCPi-FrameworkPlugins_URL} CACHE STRING ON)
-set(CCPi-FrameworkPlugins_TAG ${DEFAULT_CCPi-FrameworkPlugins_TAG} CACHE STRING ON)
 set(CCPi-Astra_URL ${DEFAULT_CCPi-Astra_URL} CACHE STRING ON)
 set(CCPi-Astra_TAG ${DEFAULT_CCPi-Astra_TAG} CACHE STRING ON)
 set(astra-toolbox_URL ${DEFAULT_astra-toolbox_URL} CACHE STRING ON)
@@ -286,11 +284,14 @@ mark_as_advanced(SIRF_URL SIRF_TAG STIR_URL STIR_TAG
   glog_URL glog_TAG
   NIFTYREG_URL NIFTYREG_TAG
   CCPi-Framework_URL CCPi-Framework_TAG
-  CCPi-FrameworkPlugins_URL CCPi-FrameworkPlugins_TAG
+  CCPi-Astra_URL CCPi-Astra_TAG
   CCPi-Regularisation-Toolkit_URL CCPi-Regularisation-Toolkit_TAG
   NiftyPET_URL NiftyPET_TAG
   SIRF-Contribs_URL SIRF-Contribs_TAG
   ITK_URL ITK_TAG
   SPM_URL SPM_TAG
   JSON_URL JSON_TAG
+  astra-toolbox_URL astra-toolbox_TAG
+  ACE_URL ACE_TAG
+  
 )


### PR DESCRIPTION
added ACE, astra-toolbox and CCPi-Astra do advanced options
Removed CCPi-FrameworkPlugins that is merged into CCPi-Framework since v20.11