### PR TITLE
add lib64 to LD_LIBRARY_PATH in environment scripts

### DIFF
--- a/env_sirf.csh.in
+++ b/env_sirf.csh.in
@@ -9,9 +9,9 @@ setenv SIRF_INSTALL_PATH @SyneRBI_INSTALL@
 # Where to find shared libraries
 # Setting for Linux but doesn't harm elsewhere
 if $?LD_LIBRARY_PATH then
-	setenv LD_LIBRARY_PATH @SyneRBI_INSTALL@/lib:$LD_LIBRARY_PATH@Matlab_extra_ld_path@
+	setenv LD_LIBRARY_PATH @SyneRBI_INSTALL@/lib:@SyneRBI_INSTALL@/lib64:$LD_LIBRARY_PATH@Matlab_extra_ld_path@
 else
-	setenv LD_LIBRARY_PATH @SyneRBI_INSTALL@/lib@Matlab_extra_ld_path@
+	setenv LD_LIBRARY_PATH @SyneRBI_INSTALL@/lib:@SyneRBI_INSTALL@/lib64:@Matlab_extra_ld_path@
 endif
 # Setting for MacOS but doesn't harm elsewhere
 if $?DYLD_FALLBACK_LIBRARY_PATH then

--- a/env_sirf.sh.in
+++ b/env_sirf.sh.in
@@ -11,7 +11,7 @@ SIRF_INSTALL_PATH=@SyneRBI_INSTALL@
 export SIRF_INSTALL_PATH
 # Where to find shared libraries
 # Setting for Linux but doesn't harm elsewhere
-LD_LIBRARY_PATH=@SyneRBI_INSTALL@/lib:$LD_LIBRARY_PATH@Matlab_extra_ld_path@
+LD_LIBRARY_PATH=@SyneRBI_INSTALL@/lib:@SyneRBI_INSTALL@/lib64:$LD_LIBRARY_PATH:@Matlab_extra_ld_path@
 export LD_LIBRARY_PATH
 # Setting for MacOS but doesn't harm elsewhere
 DYLD_FALLBACK_LIBRARY_PATH=@SyneRBI_INSTALL@/lib:$DYLD_FALLBACK_LIBRARY_PATH


### PR DESCRIPTION
add `install/lib64` to the `LD_LIBRARY_PATH` which will exist in some OS.