### PR TITLE
docker: fix UID/GID on Linux

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,8 +6,8 @@ services:
   environment:
    # mainUser: ${USER:-sirfuser}
    mainUser: sirfuser
-   GROUP_ID: ${GROUPS:-1000}
-   USER_ID: ${UID:-1000}
+   GROUP_ID: ${GROUP_ID:-1000}
+   USER_ID: ${USER_ID:-1000}
   build:
    context: .
    target: sirf

--- a/docker/sirf-compose
+++ b/docker/sirf-compose
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
 cd "$(dirname $0)"
+export GROUP_ID=$(id -g)
+export USER_ID=$(id -u)
 docker-compose -f docker-compose.yml -f docker-compose.nix.yml "$@"


### PR DESCRIPTION
`docker-compose.yml` used the special variabled `UID` and `GROUPS`, but it seems impossible to get `GROUPS` to be exported. Therefore, I switched to using non-special env variables, but set those explicitly in `sirf-compose`.

Fixes #464