### PR TITLE
disable NiftyPET by default as it requires python2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 # ChangeLog
 
 ## v3.x.x
-- no longer build NiftyPET on docker until we have transitioned it to Python3
+- disable built of NiftyPET by default as requires Python2 for which we dropped support
 
 ## v3.0.0
 - travis to use BUILD_CIL=ON for all Docker builds

--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -268,7 +268,7 @@ endif()
 
 # If building STIR and CUDA present, offer to build NiftyPET
 if (USE_CUDA AND NOT USE_SYSTEM_STIR)
-  set(USE_NiftyPET ON CACHE BOOL "Build STIR with NiftyPET's projectors") # FORCE)
+  set(USE_NiftyPET OFF CACHE BOOL "Build STIR with NiftyPET's projectors") # FORCE)
   if (USE_NiftyPET)
     option(USE_SYSTEM_NiftyPET "Build using an external version of NiftyPET" OFF)
   endif()


### PR DESCRIPTION
PR #550 disabled NiftyPET only for docker builds, however, since `NiftyPET` requires Python 2 and we dropped support for Python2 NiftyPET should just be disabled throughout and enabled by a daring user.