### PR TITLE
Try ISMRMRD 1.4.2

### DIFF
--- a/version_config.cmake
+++ b/version_config.cmake
@@ -190,7 +190,8 @@ if (DEVEL_BUILD)
   set(DEFAULT_CCPi-Regularisation-Toolkit_TAG origin/master)
 
 else()
-  set(DEFAULT_SIRF_TAG v3.0.0)
+  set(DEFAULT_SIRF_TAG 4ad0ce6d5fb34713e53328d0f559b4e42b347d8f)
+#  set(DEFAULT_SIRF_TAG v3.0.0)
 
   ## STIR
   set(DEFAULT_STIR_URL https://github.com/UCL/STIR )

--- a/version_config.cmake
+++ b/version_config.cmake
@@ -113,7 +113,7 @@ if (WIN32)
   set(DEFAULT_ISMRMRD_TAG program_options_fix)
 else()
   set(DEFAULT_ISMRMRD_URL https://github.com/ismrmrd/ismrmrd )
-  set(DEFAULT_ISMRMRD_TAG v1.4.1)
+  set(DEFAULT_ISMRMRD_TAG v1.4.2)
 endif()
 
 ## Gadgetron


### PR DESCRIPTION
Currently used ISMRMRD 1.4.1 does not correctly generate undersampled raw data (no calibration area present).

This PR tries to shift to ISMRMRD 1.4.2.