### PR TITLE
bump CIL tags

### DIFF
--- a/version_config.cmake
+++ b/version_config.cmake
@@ -151,7 +151,7 @@ set(DEFAULT_JSON_TAG v3.9.1)
 set(DEFAULT_CIL_URL https://github.com/TomographicImaging/CIL.git)
 set(DEFAULT_CIL_TAG "ca12ef252e68eaa7a3cccd19250e5481f02bcfd2")
 set(DEFAULT_CIL-ASTRA_URL https://github.com/TomographicImaging/CIL-ASTRA.git)
-set(DEFAULT_CIL-ASTRA_TAG "23003a6060062e2309ce017bd575e24844bca4d7")
+set(DEFAULT_CIL-ASTRA_TAG "v21.2.0")
 set(DEFAULT_CCPi-Regularisation-Toolkit_URL https://github.com/vais-ral/CCPi-Regularisation-Toolkit.git)
 set(DEFAULT_CCPi-Regularisation-Toolkit_TAG "v20.09")
 

--- a/version_config.cmake
+++ b/version_config.cmake
@@ -149,9 +149,9 @@ set(DEFAULT_JSON_TAG v3.9.1)
 
 # CCPi CIL
 set(DEFAULT_CIL_URL https://github.com/TomographicImaging/CIL.git)
-set(DEFAULT_CIL_TAG "v21.1.0")
+set(DEFAULT_CIL_TAG "ca12ef252e68eaa7a3cccd19250e5481f02bcfd2")
 set(DEFAULT_CIL-ASTRA_URL https://github.com/TomographicImaging/CIL-ASTRA.git)
-set(DEFAULT_CIL-ASTRA_TAG "v21.0.0")
+set(DEFAULT_CIL-ASTRA_TAG "23003a6060062e2309ce017bd575e24844bca4d7")
 set(DEFAULT_CCPi-Regularisation-Toolkit_URL https://github.com/vais-ral/CCPi-Regularisation-Toolkit.git)
 set(DEFAULT_CCPi-Regularisation-Toolkit_TAG "v20.09")
 


### PR DESCRIPTION
update CIL to latest versions pre-training. This is likely to change and the repos are going to be tagged properly, but it's for testing.