### PR TITLE
pass to SIRF if Gadgetron used CUDA

### DIFF
--- a/SuperBuild/External_SIRF.cmake
+++ b/SuperBuild/External_SIRF.cmake
@@ -105,6 +105,7 @@ if(NOT ( DEFINED "USE_SYSTEM_${externalProjName}" AND "${USE_SYSTEM_${externalPr
       -DOPENMP_INCLUDES:PATH=${OPENMP_INCLUDES}
       -DOPENMP_LIBRARIES:PATH=${OPENMP_LIBRARIES}
 		  ${extra_args}
+      -DGadgetron_USE_CUDA=${Gadgetron_USE_CUDA}
       ${${proj}_EXTRA_CMAKE_ARGS_LIST}
     DEPENDS
         ${${proj}_DEPENDENCIES}


### PR DESCRIPTION
If Gadgetron is built with CUDA, SIRF needs to pass the include to CUDA during compilation of RPE encoding code.