### PR TITLE
docker: create user with gid

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,9 @@
 # ChangeLog
 ## v3.x.x
 
-- added external project astra-python-wrapper to allow updates of ASTRA without conflicts
+- added external project astra-python-wrapper to allow updates of ASTRA without conflicts [#605](https://github.com/SyneRBI/SIRF-SuperBuild/issues/605)
+- fix docker/entrypoint for case where a user has a GID that already exists in the Docker image [#606](https://github.com/SyneRBI/SIRF-SuperBuild/issues/606)
+
 ## v3.1.0
 - docker:
   - configure nbstripout in SIRF-Exercises for `sirf-service`

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -31,7 +31,7 @@ addgroup --quiet --system --gid "$GROUP_ID" "$mainUser"
 #   -p $(echo somepassword | openssl passwd -1 -stdin)
 adduser --quiet --system --shell /bin/bash \
   --no-create-home --home /home/"$mainUser" \
-  --ingroup "$mainUser" --uid "$USER_ID" "$mainUser"
+  --gid "$GROUP_ID" --uid "$USER_ID" "$mainUser"
 addgroup "$mainUser" users
 
 echo "$mainUser ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/"$mainUser"


### PR DESCRIPTION
The entrypoint.sh failed if `GROUP_ID` refers to an existing group, as the `adduser` command referred to it via the wrong name.

Fixes #606