### PR TITLE
ITK 5.2.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 - moved the VM repository to the `VirtualBox` subdirectory
 - fix usage of `proj_EXTRA_CMAKE_ARGS` facility (it was broken for all projects except ITK) [#616](https://github.com/SyneRBI/SIRF-SuperBuild/issues/616)
 - Boost: fix cases where the wrong version of boost could be found [#627](https://github.com/SyneRBI/SIRF-SuperBuild/issues/627)
+- updated versions:
+  - ITK: 5.2.1
 
 ## v3.1.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@
 - fix usage of `proj_EXTRA_CMAKE_ARGS` facility (it was broken for all projects except ITK) [#616](https://github.com/SyneRBI/SIRF-SuperBuild/issues/616)
 - Boost: fix cases where the wrong version of boost could be found [#627](https://github.com/SyneRBI/SIRF-SuperBuild/issues/627)
 - updated versions:
-  - ITK: 5.2.1
+  - ITK: 5.2.1 However, we now build a smaller set of IO modules See SuperBuild/External_ITK.cmake)
 
 ## v3.1.1
 

--- a/README.md
+++ b/README.md
@@ -31,12 +31,14 @@ by the SuperBuild, [see below for more info for your operating system](#os-speci
    1. [use a different compiler than the system default](use-a-different-compiler-than-the-system-default)
    2. [Compiling against your own packages](#Compiling-packages)
    3. [Python and MATLAB installation locations](#Python-and-MATLAB-installation-locations)
-   4. [Building with specific versions of dependencies](#Building-with-specific-versions-of-dependencies)
-   5. [Building from your own source](#Building-from-your-own-source)
-   6. [Building with Intel Math Kernel Library](#Building-with-Intel-Math-Kernel-Library)
-   7. [Building CCPi CIL](#Building-CCPi-CIL)
-   8. [Passing CMAKE arguments to specific projects](#Passing-CMAKE-arguments-to-specific-projects)
-
+   4. [Package specific information](#Package-specific-information)
+   5. [Building with specific versions of dependencies](#Building-with-specific-versions-of-dependencies)
+   6. [Building from your own source](#Building-from-your-own-source)
+   7. [Building with Intel Math Kernel Library](#Building-with-Intel-Math-Kernel-Library)
+   8. [Building CCPi CIL](#Building-CCPi-CIL)
+   9. [Passing CMAKE arguments to specific projects](#Passing-CMAKE-arguments-to-specific-projects)
+   10. [Building with CUDA](#Building-with-CUDA)
+5. [Notes](#Notes)
 
 ## Dependencies
 
@@ -248,6 +250,30 @@ For this reason, we advise new SIRF users to compile with all the `USE_SYSTEM_*`
 By default, Python and MATLAB executables and libraries are installed under `CMAKE_INSTALL_PREFIX/python` and `CMAKE_INSTALL_PREFIX/matlab`, respectively. If you wish for them to be installed elsewhere, you can simply cut and paste these folders to their desired locations.
 
 In this case, you would then need to ensure that `PYTHONPATH` and `MATLABPATH` are updated accordingly. This is because the sourced `env_ccppetmr` will point to the original (old) location.
+
+### Package specific information
+
+For default versions built, see [version_config.cmake](version_config.cmake) and 
+[below on how to change them](#Building-with-specific-versions-of-dependencies).
+
+The SuperBuild allows building many packages and sets dependencies correctly. However, the
+emphasis is on building SIRF. Its dependent packages are therefore by default built in a
+minimal configuration. We provide some CMake variables to change that behaviour, and also
+set some main options of some packages. Most of these are "advanced" CMake options so as not to
+confuse the new user. Naming of these options is generally the same as in the original package
+but prefixed. We list main examples here, but you can check with CMake (or the `External*.cmake` files).
+(See [below](#Passing-CMAKE-arguments-to-specific-projects) for information
+on how to set other options).
+
+#### STIR
+- `STIR_BUILD_EXECUTABLES` defaults to `OFF`
+- `STIR_BUILD_SWIG_PYTHON` defaults to `OFF`, meaning that the STIR Python interface will not be built, i.e. you have to use the SIRF Python interface to STIR.
+- `STIR_DISABLE_LLN_MATRIX` defaults to `ON`, you might want to set this to `OFF` if you have GATE and use its output to ECAT sinograms (although this is not recommended).
+- `STIR_ENABLE_EXPERIMENTAL` defaults to `OFF`
+
+#### ITK
+- `ITK_MINIMAL_LIBS` defaults to `ON`. For the list of modules (concentrated on IO) built, check [External_ITK.cmake](SuperBuild/External_ITK.cmake).
+- `ITK_USE_SYSTEM_HDF5` defaults to `ON`, i.e. tell ITK to use same HDF5 library as other software built here. Note that this would normally be the HDF5 version built by the SuperBuild. Set this variables `OFF` if ITK has problems with HDF5.
 
 ### Building with specific versions of dependencies
 By default, the SuperBuild will build the latest stable release of SIRF and associated versions of the dependencies. However, the SuperBuild allows the user to change the versions of the projects it's building. The current default values can be found in [version_config.cmake](version_config.cmake).

--- a/SuperBuild/External_ITK.cmake
+++ b/SuperBuild/External_ITK.cmake
@@ -2,7 +2,7 @@
 # Author: Richard Brown
 # Author: Benjamin A Thomas
 # Author: Kris Thielemans
-# Copyright 2017, 2020 University College London
+# Copyright 2017, 2020, 2022 University College London
 #
 # This file is part of the CCP SyneRBI (formerly PETMR) Synergistic Image Reconstruction Framework (SIRF) SuperBuild.
 #
@@ -23,8 +23,12 @@
 #This needs to be unique globally
 set(proj ITK)
 
+option(ITK_USE_SYSTEM_HDF5 "ITK to use same HDF5 library as other software (set to OFF if ITK has problems with HDF5)" ON)
+
 # Set dependency list
-set(${proj}_DEPENDENCIES "HDF5")
+if (ITK_USE_SYSTEM_HDF5)
+  set(${proj}_DEPENDENCIES "HDF5")
+endif()
 
 # Include dependent projects if any
 ExternalProject_Include_Dependencies(${proj} DEPENDS_VAR ${proj}_DEPENDENCIES)
@@ -51,16 +55,42 @@ if(NOT ( DEFINED "USE_SYSTEM_${externalProjName}" AND "${USE_SYSTEM_${externalPr
 
   OPTION(ITK_MINIMAL_LIBS "Only build ITK IO libraries" ON)
   if (ITK_MINIMAL_LIBS)
+    # Currently we only build some of the IO Modules. In fact, we don't even enable all
+    # IO modules as this minimises size and compilation time, and also
+    # increases chances of success of compilation.
+    # For example, ITKIOMINC fails to build with system HDF5 1.10.0 - 1.10.1,
+    # while sadly Ubuntu 18.04 comes with HDF 1.10.0.
 
     # -DModule_ITKReview:BOOL=ON # should be ON for PETPVC, but not for others
+    # ITKImageGrid is ON as it contains itkOrientImageFilter, used by STIR
     set(ITK_CMAKE_FLAGS
       -DITK_BUILD_DEFAULT_MODULES:BOOL=OFF
-      -DITKGroup_IO:BOOL=ON
+      -DITKGroup_IO:BOOL=OFF
+      -DModule_ITKIOBMP:BOOL=ON
+      -DModule_ITKIOGDCM:BOOL=ON
+      -DModule_ITKIOGIPL:BOOL=ON
+      -DModule_ITKIOJPEG:BOOL=ON
+      -DModule_ITKIOJPEG2000:BOOL=ON
+      -DModule_ITKIOMeta:BOOL=ON
+      -DModule_ITKIONIFTI:BOOL=ON
+      -DModule_ITKIONRRD:BOOL=ON
+      -DModule_ITKIOPNG:BOOL=ON
+      -DModule_ITKIORAW:BOOL=ON
+      -DModule_ITKIOTIFF:BOOL=ON
+      -DModule_ITKImageGrid:BOOL=ON
       )
   else()
 
     set(ITK_CMAKE_FLAGS
       -DITK_BUILD_DEFAULT_MODULES:BOOL=ON
+      )
+  endif()
+
+  set(ITK_CMAKE_FLAGS ${ITK_CMAKE_FLAGS}
+    -DITK_USE_SYSTEM_HDF5:BOOL=${ITK_USE_SYSTEM_HDF5})
+  if (ITK_USE_SYSTEM_HDF5)
+    set(ITK_CMAKE_FLAGS ${ITK_CMAKE_FLAGS}
+      ${HDF5_CMAKE_ARGS}
       )
   endif()
 
@@ -75,8 +105,6 @@ if(NOT ( DEFINED "USE_SYSTEM_${externalProjName}" AND "${USE_SYSTEM_${externalPr
       -DCMAKE_INCLUDE_PATH:PATH=${SUPERBUILD_INSTALL_DIR}
       -DCMAKE_INSTALL_PREFIX:PATH=${${proj}_INSTALL_DIR}
 	    -DBUILD_SHARED_LIBS:BOOL=${ITK_SHARED_LIBS}
-      ${HDF5_CMAKE_ARGS}
-      -DITK_USE_SYSTEM_HDF5:BOOL=ON
       -DBUILD_TESTING:BOOL=${BUILD_TESTING_${proj}}
       -DBUILD_EXAMPLES:BOOL=OFF
       -DITK_SKIP_PATH_LENGTH_CHECKS:BOOL=${ITK_SKIP_PATH_LENGTH_CHECKS}

--- a/version_config.cmake
+++ b/version_config.cmake
@@ -100,7 +100,7 @@ set(DEFAULT_glog_TAG v0.3.5)
 
 ## ITK
 set(DEFAULT_ITK_URL https://github.com/InsightSoftwareConsortium/ITK.git)
-set(DEFAULT_ITK_TAG v4.13.1)
+set(DEFAULT_ITK_TAG v5.2.1)
 
 ## NIFTYREG
 set(DEFAULT_NIFTYREG_URL https://github.com/KCL-BMEIS/niftyreg.git )


### PR DESCRIPTION
Upgrade ITK. I had to disable the MINC part of the IO library as it failed to compile with Ubuntu's HDF5 library:
```
The selected version of HDF5 library does not support setting backwards compatibility at run-time.\
  Please use a different version of HDF5
```
generated at https://github.com/InsightSoftwareConsortium/ITK/blob/master/Modules/ThirdParty/MINC/src/libminc/libsrc2/volume.c#L39-L40

An alternative would be to set `ITK_USE_SYSTEM_HDF5=OFF`, at the expense of larger ITK build. I have introduced an option to be able to do this.

@ashgillman any opinions on this?