### PR TITLE
fix siemens_to_ismrmrd to 6d0ab3d3d0c8ade5c0526db1c6af9825008425ad

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 - add the CERN ROOT library (if USE_ROOT=ON, but defaults to OFF), which can be used by STIR to read GATE ROOT files.
 - updated versions:
   - ISMRMRD: 1.5.0
+  - siemens_to_ismrmrd: [6d0ab3d3d0c8ade5c0526db1c6af9825008425ad](https://github.com/ismrmrd/siemens_to_ismrmrd/commit/6d0ab3d3d0c8ade5c0526db1c6af9825008425ad)
   - ITK: 5.2.1 However, we now build a smaller set of modules,
      most (but not all) of IO, and Filtering. See SuperBuild/External_ITK.cmake)
   - NiftyReg: 99d584e2b8ea0bffe7e65e40c8dc818751782d92 ) (fixes gcc-9 OpenMP problems)

--- a/version_config.cmake
+++ b/version_config.cmake
@@ -178,7 +178,7 @@ if (DEVEL_BUILD)
 
   ## siemens_to_ismrmrd
   set(DEFAULT_siemens_to_ismrmrd_URL https://github.com/ismrmrd/siemens_to_ismrmrd )
-  set(DEFAULT_siemens_to_ismrmrd_TAG origin/master)
+  set(DEFAULT_siemens_to_ismrmrd_TAG 6d0ab3d3d0c8ade5c0526db1c6af9825008425ad)
 
   ## pet-rd-tools
   set(DEFAULT_pet_rd_tools_URL https://github.com/UCL/pet-rd-tools )
@@ -204,7 +204,7 @@ else()
 
   ## siemens_to_ismrmrd
   set(DEFAULT_siemens_to_ismrmrd_URL https://github.com/ismrmrd/siemens_to_ismrmrd)
-  set(DEFAULT_siemens_to_ismrmrd_TAG ba4773f9cf4bba5f3ccd19930e3548d8273fee01)
+  set(DEFAULT_siemens_to_ismrmrd_TAG 6d0ab3d3d0c8ade5c0526db1c6af9825008425ad)
 
   ## pet-rd-tools
   set(DEFAULT_pet_rd_tools_URL https://github.com/UCL/pet-rd-tools )


### PR DESCRIPTION
- `DEVEL_BUILD` was on `origin/master`, causing problems as it is too recent compared to ISMRMRD 1.5.0.
- default build was a fairly old version, likely causing problems with ISMRMRD 1.5.0.