### PR TITLE
bump CIL version

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,7 +20,7 @@
   - ITK: 5.2.1 However, we now build a smaller set of modules,
      most (but not all) of IO, and Filtering. See SuperBuild/External_ITK.cmake)
   - NiftyReg: 99d584e2b8ea0bffe7e65e40c8dc818751782d92 ) (fixes gcc-9 OpenMP problems)
-  - CIL: f5c06566215564ad78ba0f1738d0836f3ad37a60 > v21.3.1  which contains a bugfix in a unittest [#658](https://github.com/SyneRBI/SIRF-SuperBuild/issues/658)
+  - CIL: fc2e97d8c33c4108e134394330bcd0d053597aca > v21.3.1  which contains a bugfix in a unittest [#658](https://github.com/SyneRBI/SIRF-SuperBuild/issues/658)
   - GTest: 1.11.0
   - Boost: 1.72.0
   - JSON: 3.10.4

--- a/version_config.cmake
+++ b/version_config.cmake
@@ -151,7 +151,7 @@ set(DEFAULT_JSON_TAG v3.10.4)
 # CCPi CIL
 set(DEFAULT_CIL_URL https://github.com/TomographicImaging/CIL.git)
 # TODO update to a tagged version > v21.3.1 once available
-set(DEFAULT_CIL_TAG f5c06566215564ad78ba0f1738d0836f3ad37a60)
+set(DEFAULT_CIL_TAG fc2e97d8c33c4108e134394330bcd0d053597aca)
 set(DEFAULT_CIL-ASTRA_URL https://github.com/TomographicImaging/CIL-ASTRA.git)
 set(DEFAULT_CIL-ASTRA_TAG "v21.3.0")
 set(DEFAULT_CCPi-Regularisation-Toolkit_URL https://github.com/vais-ral/CCPi-Regularisation-Toolkit.git)


### PR DESCRIPTION
bugfix https://github.com/TomographicImaging/CIL/pull/1227
removes failures in GHA https://github.com/SyneRBI/SIRF-SuperBuild/pull/693#issuecomment-1109385847