### PR TITLE
set CIL version to 21.4.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,7 +21,7 @@
   - ITK: 5.2.1 However, we now build a smaller set of modules,
      most (but not all) of IO, and Filtering. See SuperBuild/External_ITK.cmake)
   - NiftyReg: 99d584e2b8ea0bffe7e65e40c8dc818751782d92 ) (fixes gcc-9 OpenMP problems)
-  - CIL: 36ec5160c4d26cc2612719dddcdb5405408b9797 > v21.3.1  which contains a bugfix in a unittest [#658](https://github.com/SyneRBI/SIRF-SuperBuild/issues/658)
+  - CIL: v21.4.0
   - GTest: 1.11.0
   - Boost: 1.72.0
   - JSON: 3.10.4

--- a/version_config.cmake
+++ b/version_config.cmake
@@ -150,8 +150,7 @@ set(DEFAULT_JSON_TAG v3.10.4)
 
 # CCPi CIL
 set(DEFAULT_CIL_URL https://github.com/TomographicImaging/CIL.git)
-# TODO update to a tagged version > v21.3.1 once available
-set(DEFAULT_CIL_TAG 36ec5160c4d26cc2612719dddcdb5405408b9797)
+set(DEFAULT_CIL_TAG "v21.4.0")
 set(DEFAULT_CIL-ASTRA_URL https://github.com/TomographicImaging/CIL-ASTRA.git)
 set(DEFAULT_CIL-ASTRA_TAG "v21.3.0")
 set(DEFAULT_CCPi-Regularisation-Toolkit_URL https://github.com/vais-ral/CCPi-Regularisation-Toolkit.git)


### PR DESCRIPTION
update the version of CIL to the latest (today's) tagged version.