### PR TITLE
[ci skip] updates the path in the update_VM.sh script

### DIFF
--- a/VirtualBox/scripts/update_VM.sh
+++ b/VirtualBox/scripts/update_VM.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 echo "Updating..."
-cd ~/devel/SyneRBI_VM
+cd ~/devel/SIRF-SuperBuild/VirtualBox
 git pull
 cd scripts
 


### PR DESCRIPTION
The script `update_VM.sh` refers to the archived repo https://github.com/SyneRBI/SyneRBI_VM 
https://github.com/SyneRBI/SIRF-SuperBuild/blob/775d4a18bccc0bc67b194622eb976acd61620a8f/VirtualBox/scripts/update_VM.sh#L4-L6

I updated the location of the `UPDATE.sh` script.