### PR TITLE
Add Boost regex and random for Windows build

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 # ChangeLog
 # v3.x.x
+- Windows Boost build add regex and random
 - VM: 
   - set BUILD_CIL=ON
 - updated versions:

--- a/SuperBuild/External_Boost_buildboost.cmake
+++ b/SuperBuild/External_Boost_buildboost.cmake
@@ -22,7 +22,7 @@ if(WIN32)
   # TODO: would be better to use a variable but for some reason KT cannot pass the variable to the execute_process
   # without strange error messages of b2
   
-  execute_process(COMMAND ./b2 --with-system --with-filesystem --with-thread --with-program_options --with-chrono --with-date_time --with-atomic  --with-timer --with-test install --prefix=${BOOST_INSTALL_DIR}
+  execute_process(COMMAND ./b2 --with-system --with-filesystem --with-thread --with-program_options --with-chrono --with-date_time --with-atomic  --with-timer --with-test --with-random --with-regex install --prefix=${BOOST_INSTALL_DIR}
     WORKING_DIRECTORY ${BUILD_DIR} RESULT_VARIABLE build_result)
 
 else(WIN32)


### PR DESCRIPTION
Adds `regex` and `random` to Windows Boost build, but they are not responsible for the issue #720 