### PR TITLE
Fix astra update

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # ChangeLog
 # v3.x.x
 - Windows Boost build add regex and random
+- Update to the ASTRA build script
 - VM: 
   - set BUILD_CIL=ON
 - updated versions:

--- a/SuperBuild/External_astra-python-wrapper.cmake
+++ b/SuperBuild/External_astra-python-wrapper.cmake
@@ -112,7 +112,9 @@ cp -rv ${${astra}_SOURCE_DIR}/python/build/$build_dir/astra ${${proj}_INSTALL_DI
     file(COPY ${${proj}_BINARY_DIR}/python_install
          DESTINATION ${${proj}_BINARY_DIR}/python
          FILE_PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ)
-    
+    # remove the files in the repo directory that give troubles to git
+    file(REMOVE ${${proj}_BINARY_DIR}/python_build)
+    file(REMOVE ${${proj}_BINARY_DIR}/python_install)
 
     # SetCanonicalDirectoryNames("${proj}")
     SetGitTagAndRepo("${proj}")

--- a/SuperBuild/External_astra-toolbox.cmake
+++ b/SuperBuild/External_astra-toolbox.cmake
@@ -70,6 +70,7 @@ if(NOT ( DEFINED "USE_SYSTEM_${externalProjName}" AND "${USE_SYSTEM_${externalPr
       
 
       # This build is Unix specific
+      UPDATE_COMMAND ${CMAKE_COMMAND} -E rm ${${proj}_SOURCE_DIR}/python/python_build && ${CMAKE_COMMAND} -E rm ${${proj}_SOURCE_DIR}/python/python_install
       CONFIGURE_COMMAND
         ${CMAKE_COMMAND} -E chdir ${${proj}_SOURCE_DIR}/build/linux ./autogen.sh
       BUILD_COMMAND

--- a/SuperBuild/External_astra-toolbox.cmake
+++ b/SuperBuild/External_astra-toolbox.cmake
@@ -70,7 +70,7 @@ if(NOT ( DEFINED "USE_SYSTEM_${externalProjName}" AND "${USE_SYSTEM_${externalPr
       
 
       # This build is Unix specific
-      UPDATE_COMMAND ${CMAKE_COMMAND} -E rm ${${proj}_SOURCE_DIR}/python/python_build && ${CMAKE_COMMAND} -E rm ${${proj}_SOURCE_DIR}/python/python_install
+      UPDATE_COMMAND ${CMAKE_COMMAND} -E rm -f ${${proj}_SOURCE_DIR}/python/python_build && ${CMAKE_COMMAND} -E rm -f ${${proj}_SOURCE_DIR}/python/python_install
       CONFIGURE_COMMAND
         ${CMAKE_COMMAND} -E chdir ${${proj}_SOURCE_DIR}/build/linux ./autogen.sh
       BUILD_COMMAND


### PR DESCRIPTION
closes #743 

- Removes files that may be present in the source directory by `cmake -E rm -f`. 
- Removes temporary scripts from where they have been created after they have been copied to the right destination. 

