### PR TITLE
Set CIL version to commit before CIL-ASTRA merge

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@
 - VM: 
   - set BUILD_CIL=ON
 - add CITATION.cff (and remove .zenodo.json)
+- added numba as dependency in docker files
 - updated versions:
   - SIRF: 3.3.0
   - STIR: 5.0.2

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@
   - STIR: 5.0.2
   - parallelproj: v0.8
   - CCPi Regularisation: v21.0.0
+  - CIL: v21.4.1 (CIL devel build to commit hash ef66083de231492f9571f5512b33068f6950e877 )
 
 
 ## v3.2.0

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -10,6 +10,7 @@ wget         # CIL
 six          # CIL
 olefile      # CIL
 git+https://github.com/data-exchange/dxchange.git  # CIL
+numba        # CIL
 pandas
 tifffile
 nibabel

--- a/docker/requirements_conda_forge.txt
+++ b/docker/requirements_conda_forge.txt
@@ -8,3 +8,4 @@ tigre
 tomophantom=1.4.10
 python-wget
 dxchange
+numba

--- a/version_config.cmake
+++ b/version_config.cmake
@@ -200,7 +200,7 @@ if (DEVEL_BUILD)
 
   # CCPi CIL
   set(DEFAULT_CIL_URL https://github.com/TomographicImaging/CIL.git)
-  set(DEFAULT_CIL_TAG origin/master)
+  set(DEFAULT_CIL_TAG ef66083de231492f9571f5512b33068f6950e877 )
   set(DEFAULT_CIL-ASTRA_URL https://github.com/TomographicImaging/CIL-ASTRA.git)
   set(DEFAULT_CIL-ASTRA_TAG origin/master)
 


### PR DESCRIPTION
CIL-ASTRA has been merged (and patched) into CIL code (after a lengthy relicensing procedure), so now, the SuperBuild installs CIL-ASTRA master (not patched) on top of the correct master CIL code, resulting in the [error](https://github.com/SyneRBI/SIRF-SuperBuild/runs/7601445525?check_suite_focus=true). 