### PR TITLE
pass DISABLE_Gadgetron to SIRF

### DIFF
--- a/SuperBuild/External_SIRF.cmake
+++ b/SuperBuild/External_SIRF.cmake
@@ -106,6 +106,7 @@ if(NOT ( DEFINED "USE_SYSTEM_${externalProjName}" AND "${USE_SYSTEM_${externalPr
       -DOPENMP_LIBRARIES:PATH=${OPENMP_LIBRARIES}
 		  ${extra_args}
       -DGadgetron_USE_CUDA=${Gadgetron_USE_CUDA}
+      -DDISABLE_Gadgetron=(NOT ${BUILD_Gadgetron})
       ${${proj}_EXTRA_CMAKE_ARGS}
     DEPENDS
         ${${proj}_DEPENDENCIES}


### PR DESCRIPTION
Partly addresses #750 by setting `DISABLE_Gadgetron=(NOT ${BUILD_Gadgetron}) `in SIRF's external build.

This is however, still not entirely correct as it does not address:

1. `USE_SYSTEM_Gadgetron=ON`
2. the case in which `BUILD_Gadgetron=ON` but the user wants (why would they?) to disable Gadgetron's support in SIRF.