### PR TITLE
[docker/VM]: add uuid-dev apt package

### DIFF
--- a/docker/build_system-ubuntu.sh
+++ b/docker/build_system-ubuntu.sh
@@ -70,4 +70,8 @@ ${APT_GET_INSTALL} \
   autoconf             \
   libtool
 
+# ROOT external dependencies
+${APT_GET_INSTALL} \
+  uuid-dev
+
 apt-get clean


### PR DESCRIPTION
This allows building ROOT if a user would want to (or we ourselves in the future)

Fixes #728