### PR TITLE
fix GHA problems on Ubuntu 22.04

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -149,7 +149,7 @@ jobs:
       uses: actions/upload-artifact@v3
       if: failure()
       with:
-        name: build_log_files-${{ matrix.os }}-${{ matrix.compiler }}${{ matrix.compiler_version }}-${{ matrix.BUILD_TYPE }}-DEVEL=${{ matrix.DEVEL_BUILD }}-EXTRA=${{ matrix.EXTRA_BUILD_FLAGS }}
+        name: build_log_files-${{ matrix.os }}-${{ matrix.compiler }}${{ matrix.compiler_version }}-${{ matrix.BUILD_TYPE }}-DEVEL=${{ matrix.DEVEL_BUILD }}-run=${{ github.run_number }}-id=${{ github.run_id }}
         path: ${{ github.workspace }}/build/**/*.log
         retention-days: 7
 

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -59,7 +59,7 @@ jobs:
           BUILD_TYPE: "Release"
           EXTRA_BUILD_FLAGS: "-DUSE_ITK=ON -DBUILD_CIL=ON -DUSE_SYSTEM_ACE=ON -DUSE_SYSTEM_Armadillo=OFF -DUSE_SYSTEM_Boost=ON -DUSE_SYSTEM_FFTW3=ON -DUSE_SYSTEM_HDF5=ON -DBUILD_siemens_to_ismrmrd=ON -DUSE_SYSTEM_SWIG=ON -DUSE_ROOT:BOOL=ON"
           DEVEL_BUILD: "ON"
-        - os: ubuntu-latest
+        - os: ubuntu-20.04
           compiler: gcc
           compiler_version: 8
           BUILD_TYPE: "Release"

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -55,7 +55,7 @@ jobs:
           DEVEL_BUILD: "OFF"
         - os: ubuntu-latest
           compiler: gcc
-          compiler_version: 9
+          compiler_version: 11
           BUILD_TYPE: "Release"
           EXTRA_BUILD_FLAGS: "-DUSE_ITK=ON -DBUILD_CIL=ON -DUSE_SYSTEM_ACE=ON -DUSE_SYSTEM_Armadillo=OFF -DUSE_SYSTEM_Boost=ON -DUSE_SYSTEM_FFTW3=ON -DUSE_SYSTEM_HDF5=ON -DBUILD_siemens_to_ismrmrd=ON -DUSE_SYSTEM_SWIG=ON -DUSE_ROOT:BOOL=ON"
           DEVEL_BUILD: "ON"

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -93,7 +93,7 @@ jobs:
           sudo bash build_system-ubuntu.sh;
           PYTHON_EXECUTABLE=python3 PYTHON_INSTALL_DIR=~/virtualenv bash user_python-ubuntu.sh;
     - name: ccache
-      uses: hendrikmuhs/ccache-action@v1
+      uses: hendrikmuhs/ccache-action@v1.2
       with:
         key: ${{ matrix.os }}-${{ matrix.compiler }}-${{ matrix.compiler_version }}-${{ matrix.BUILD_TYPE }}
     - name: set_compiler_variables

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -145,6 +145,14 @@ jobs:
       timeout-minutes: 15
       if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled }}
 
+    - name: Upload build log files for debugging
+      uses: actions/upload-artifact@v3
+      if: failure()
+      with:
+        name: build_log_files-${{ matrix.os }}-${{ matrix.compiler }}${{ matrix.compiler_version }}-${{ matrix.BUILD_TYPE }}-DEVEL=${{ matrix.DEVEL_BUILD }}-EXTRA=${{ matrix.EXTRA_BUILD_FLAGS }}
+        path: ${{ github.workspace }}/build/**/*.log
+        retention-days: 7
+
     - name: tests
       shell: bash
       run: 

--- a/docker/build_system-ubuntu.sh
+++ b/docker/build_system-ubuntu.sh
@@ -7,6 +7,12 @@ APT_GET_INSTALL="apt-get install -yq --no-install-recommends"
 ${APT_GET_INSTALL} software-properties-common # needed for add-apt-repository
 add-apt-repository -y universe # needed for hdf5 for instance
 
+# Fix a problem on Ubuntu 22.04 (or at least the one on GitHub Actions)
+# of a pinned version of libunwind that then creates problems later
+# (we allow the remove/install to failthough)
+apt-get remove libunwind-14 -y || true
+${APT_GET_INSTALL} libunwind || true
+
 # echo "Installing boost 1.65 or later"
 # first find current boost version (if any)
 function find_boost_version() {

--- a/version_config.cmake
+++ b/version_config.cmake
@@ -167,7 +167,7 @@ set(DEFAULT_CCPi-Regularisation-Toolkit_TAG "v21.0.0")
 
 # CERN ROOT
 set(DEFAULT_ROOT_URL https://github.com/root-project/root)
-set(DEFAULT_ROOT_TAG "v6-24-06")
+set(DEFAULT_ROOT_TAG "v6-26-10")
 
 # ACE
 set(DEFAULT_ACE_URL https://github.com/paskino/libace-conda)

--- a/version_config.cmake
+++ b/version_config.cmake
@@ -209,7 +209,7 @@ if (DEVEL_BUILD)
 
 else()
   #set(DEFAULT_SIRF_TAG v3.3.0)
-  set (DEFAULT_SIRF_TAG 93f280fbfc95f914642d1a532a65882d83938eb5)
+  set (DEFAULT_SIRF_TAG 2ed708bb8c8dc4ac6e1b081a1f9800754621b5fd)
   
   ## STIR
   set(DEFAULT_STIR_URL https://github.com/UCL/STIR )


### PR DESCRIPTION
On GHA, libunwind-14 is installed, but that creates trouble for other packages.

Fixes https://github.com/SyneRBI/SIRF/issues/1155