### PR TITLE
add no to conda install

### DIFF
--- a/docker/user_python-ubuntu.sh
+++ b/docker/user_python-ubuntu.sh
@@ -28,7 +28,7 @@ case "$PYTHON" in
 miniconda)
   # miniconda
   curl https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh > miniconda.sh
-  echo -e "\nyes\n${INSTALL_DIR}" | bash miniconda.sh
+  echo -e "\nyes\n${INSTALL_DIR}\nno" | bash miniconda.sh
   rm miniconda.sh
   source "$INSTALL_DIR"/bin/activate
   conda config --add channels conda-forge


### PR DESCRIPTION
Apparently the new miniconda installer asks for 3 inputs. 

closes #806 