### PR TITLE
Pugixml for ISMRMD and other small fixes

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -197,7 +197,7 @@ option(USE_SYSTEM_NIFTYREG "Build using an external version of NIFTYREG" OFF)
 option(USE_SYSTEM_GTest "Build using an external version of GTest" OFF)
 option(USE_SYSTEM_ACE "Build using an external version of ACE" ON)
 option(USE_SYSTEM_RocksDB "Build using an external version of RocksDB" ON)
-option(USE_SYSTEM_Date "Build using an external version of Data" ON)
+option(USE_SYSTEM_Date "Build using an external version of Date" OFF)
 option(USE_SYSTEM_pugixml "Build using an external version of pugixml" ON)
 
 # SPM requires matlab

--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -197,6 +197,8 @@ option(USE_SYSTEM_NIFTYREG "Build using an external version of NIFTYREG" OFF)
 option(USE_SYSTEM_GTest "Build using an external version of GTest" OFF)
 option(USE_SYSTEM_ACE "Build using an external version of ACE" ON)
 option(USE_SYSTEM_RocksDB "Build using an external version of RocksDB" ON)
+option(USE_SYSTEM_Date "Build using an external version of Data" ON)
+option(USE_SYSTEM_pugixml "Build using an external version of pugixml" ON)
 
 # SPM requires matlab
 if (BUILD_MATLAB)

--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -300,6 +300,7 @@ endif()
 
 if (BUILD_Gadgetron)
   list(APPEND ${PRIMARY_PROJECT_NAME}_DEPENDENCIES Gadgetron)
+  list(APPEND ${PRIMARY_PROJECT_NAME}_DEPENDENCIES mrd-storage-server)
   set(Armadillo_REQUIRED_VERSION 4.600)
 endif()
 option(DISABLE_range-v3_TESTING "Disable range-v3 testing" ON)

--- a/SuperBuild/External_Gadgetron.cmake
+++ b/SuperBuild/External_Gadgetron.cmake
@@ -25,7 +25,7 @@
 set(proj Gadgetron)
 
 # Set dependency list
-set(${proj}_DEPENDENCIES "ACE;Boost;HDF5;ISMRMRD;FFTW3double;Armadillo;GTest;range-v3;JSON;RocksDB;Date;mrd-storage-server")
+set(${proj}_DEPENDENCIES "ACE;Boost;HDF5;ISMRMRD;FFTW3double;Armadillo;GTest;range-v3;JSON;RocksDB;Date")
 
 # Include dependent projects if any
 ExternalProject_Include_Dependencies(${proj} DEPENDS_VAR ${proj}_DEPENDENCIES)

--- a/SuperBuild/External_ISMRMRD.cmake
+++ b/SuperBuild/External_ISMRMRD.cmake
@@ -25,7 +25,7 @@
 set(proj ISMRMRD)
 
 # Set dependency list
-set(${proj}_DEPENDENCIES "HDF5;Boost;FFTW3")
+set(${proj}_DEPENDENCIES "HDF5;Boost;FFTW3;pugixml")
 
 # Include dependent projects if any
 ExternalProject_Include_Dependencies(${proj} DEPENDS_VAR ${proj}_DEPENDENCIES)

--- a/SuperBuild/External_pugixml.cmake
+++ b/SuperBuild/External_pugixml.cmake
@@ -1,0 +1,68 @@
+#========================================================================
+# Author: Edoardo Pasca
+# Copyright 2022 UKRI STFC
+#
+# This file is part of the CCP SyneRBI (formerly PETMR) Synergistic Image Reconstruction Framework (SIRF) SuperBuild.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#=========================================================================
+#This needs to be unique globally
+set(proj pugixml)
+
+# Set dependency list
+set(${proj}_DEPENDENCIES "")
+
+# Include dependent projects if any
+ExternalProject_Include_Dependencies(${proj} DEPENDS_VAR ${proj}_DEPENDENCIES)
+
+# Set external name (same as internal for now)
+set(externalProjName ${proj})
+SetCanonicalDirectoryNames(${proj})
+
+if(NOT ( DEFINED "USE_SYSTEM_${externalProjName}" AND "${USE_SYSTEM_${externalProjName}}" ) )
+  message(STATUS "${__indent}Adding project ${proj}")
+  
+  ### --- Project specific additions here
+ 
+
+  # Sets ${proj}_URL_MODIFIED and ${proj}_TAG_MODIFIED
+  SetGitTagAndRepo("${proj}")
+
+  # conda build should never get here
+  if("${PYTHON_STRATEGY}" STREQUAL "PYTHONPATH")
+    # in case of PYTHONPATH it is sufficient to copy the files to the 
+    # $PYTHONPATH directory
+    ExternalProject_Add(${proj}
+      ${${proj}_EP_ARGS}
+      ${${proj}_EP_ARGS_GIT}
+      ${${proj}_EP_ARGS_DIRS}
+      CMAKE_ARGS -DCMAKE_INSTALL_INCLUDEDIR:PATH=${SUPERBUILD_INSTALL_DIR}/include
+      DEPENDS ${${proj}_DEPENDENCIES}
+    )
+
+  else()
+    # if SETUP_PY one can launch the conda build.sh script setting 
+    # the appropriate variables.
+    message(FATAL_ERROR "Only PYTHONPATH install method is currently supported")
+  endif()
+
+else()
+    ExternalProject_Add_Empty(${proj} DEPENDS "${${proj}_DEPENDENCIES}"
+      SOURCE_DIR ${${proj}_SOURCE_DIR}
+      BINARY_DIR ${${proj}_BINARY_DIR}
+      DOWNLOAD_DIR ${${proj}_DOWNLOAD_DIR}
+      STAMP_DIR ${${proj}_STAMP_DIR}
+      TMP_DIR ${${proj}_TMP_DIR}
+    )
+endif()

--- a/VirtualBox/scripts/INSTALL_prerequisites_with_apt-get.sh
+++ b/VirtualBox/scripts/INSTALL_prerequisites_with_apt-get.sh
@@ -31,7 +31,6 @@ $SUDO "$SCRIPTS/build_system-ubuntu.sh"
 
 echo "Installing Gadgetron pre-requisites..."
 $SUDO "$SCRIPTS/build_gadgetron-ubuntu.sh"
-${APT_GET_INSTALL} libpugixml-dev
 
 echo "Installing expect"
 ${APT_GET_INSTALL} expect

--- a/version_config.cmake
+++ b/version_config.cmake
@@ -21,26 +21,18 @@
 #
 #=========================================================================
 
-## BOOST  # Gadgetron needs at least 1.65
-if (APPLE) # really should be checking for CLang
-	# Boost 1.65 contains a bug for recent Clang https://github.com/SyneRBI/SIRF-SuperBuild/issues/170
-    set(Boost_VERSION 1.68.0)
-    set(Boost_REQUIRED_VERSION 1.66.0)
-    set(Boost_URL http://downloads.sourceforge.net/project/boost/boost/${Boost_VERSION}/boost_1_68_0.zip)
-    set(Boost_MD5 f4096c4583947b0eb103c8539f1623a3)
+## BOOST
+if (BUILD_GADGETRON)
+# https://github.com/gadgetron/gadgetron/blob/12ffc43debb9bad2e170713006d29dea78d966bf/CMakeLists.txt#L205-L209
+  set(Boost_REQUIRED_VERSION 1.71.0)
 else()
-     # Use version 1.78.0 version
-     set(Boost_VERSION 1.78.0)
-     if (BUILD_GADGETRON)
-     # https://github.com/gadgetron/gadgetron/blob/12ffc43debb9bad2e170713006d29dea78d966bf/CMakeLists.txt#L205-L209
-       set(Boost_REQUIRED_VERSION 1.71.0)
-     else()
-       # Ubutnu 22.04 version should be fine
-       set(Boost_REQUIRED_VERSION 1.58.0)
-     endif()
-     set(Boost_URL http://downloads.sourceforge.net/project/boost/boost/${Boost_VERSION}/boost_1_78_0.zip)
-     set(Boost_MD5 e193e5089060ed6ce5145c8eb05e67e3)
+  # ISMRMRD needs more recent 1.68.0 so let's just say 1.71.0 as well
+  set(Boost_REQUIRED_VERSION 1.71.0)
 endif()
+set(Boost_VERSION 1.78.0)
+set(Boost_URL http://downloads.sourceforge.net/project/boost/boost/${Boost_VERSION}/boost_1_78_0.zip)
+set(Boost_MD5 e193e5089060ed6ce5145c8eb05e67e3)
+
 
 ## Armadillo
 set(Armadillo_URL https://downloads.sourceforge.net/project/arma/armadillo-9.800.2.tar.xz)

--- a/version_config.cmake
+++ b/version_config.cmake
@@ -174,6 +174,9 @@ set(DEFAULT_mrd-storage-server_TAG origin/main)
 set(DEFAULT_Date_URL https://github.com/HowardHinnant/date.git )
 set(DEFAULT_Date_TAG master)
 
+set(DEFAULT_pugixml_URL https://github.com/zeux/pugixml.git )
+set(DEFAULT_pugixml_TAG v1.13)
+
 # works only for Linux
 set(Go_URL https://go.dev/dl/go1.19.3.linux-amd64.tar.gz)
 set(Go_SHA256 74b9640724fd4e6bb0ed2a1bc44ae813a03f1e72a4c76253e2d5c015494430ba)
@@ -309,6 +312,9 @@ set(mrd-storage-server_TAG ${DEFAULT_mrd-storage-server_TAG} CACHE STRING ON)
 
 set(Date_URL ${DEFAULT_Date_URL} CACHE STRING ON)
 set(Date_TAG ${DEFAULT_Date_TAG} CACHE STRING ON)
+
+set(pugixml_URL ${DEFAULT_pugixml_URL} CACHE STRING ON)
+set(pugixml_TAG ${DEFAULT_pugixml_TAG} CACHE STRING ON)
 
 mark_as_advanced(SIRF_URL SIRF_TAG STIR_URL STIR_TAG
   Gadgetron_URL Gadgetron_TAG


### PR DESCRIPTION
ISMRMRD needs pugixml these days, and my CentOS system doesn't have it.

I also updated Boost requirements as ISMRMRD failed to compile with boost 1.68.0