### PR TITLE
test CCPi Regularisers on SIRF object

### DIFF
--- a/SuperBuild/External_CIL.cmake
+++ b/SuperBuild/External_CIL.cmake
@@ -134,6 +134,9 @@ if(NOT ( DEFINED "USE_SYSTEM_${externalProjName}" AND "${USE_SYSTEM_${externalPr
   add_test(NAME CIL_FRAMEWORK_TESTS_15
            COMMAND ${PYTHON_EXECUTABLE} -m unittest discover -p test_TranslateFunction.py
            WORKING_DIRECTORY ${${proj}_SOURCE_DIR}/Wrappers/Python/test)
+  add_test(NAME CIL_SIRF_INTEGRATION_TESTS
+           COMMAND ${PYTHON_EXECUTABLE} -m unittest discover -p test_SIRF.py
+           WORKING_DIRECTORY ${${proj}_SOURCE_DIR}/Wrappers/Python/test)
   # add_test(NAME CIL_FRAMEWORK_TESTS_ALL
   #          COMMAND ${PYTHON_EXECUTABLE} -m unittest discover
   #          WORKING_DIRECTORY ${${proj}_SOURCE_DIR}/Wrappers/Python/test)

--- a/version_config.cmake
+++ b/version_config.cmake
@@ -148,7 +148,8 @@ set(DEFAULT_JSON_TAG v3.10.4)
 # CCPi CIL
 # minimum supported version of CIL supported is > 22.1.0 or from commit a6062410028c9872c5b355be40b96ed1497fed2a
 set(DEFAULT_CIL_URL https://github.com/TomographicImaging/CIL.git)
-set(DEFAULT_CIL_TAG a6062410028c9872c5b355be40b96ed1497fed2a)
+# set(DEFAULT_CIL_TAG a6062410028c9872c5b355be40b96ed1497fed2a)
+set(DEFAULT_CIL_TAG regulariser_handle_non_cil)
 
 set(DEFAULT_CCPi-Regularisation-Toolkit_URL https://github.com/vais-ral/CCPi-Regularisation-Toolkit.git)
 set(DEFAULT_CCPi-Regularisation-Toolkit_TAG "v21.0.0")


### PR DESCRIPTION
Test whether CCPi Regularisers work on SIRF Objects. See https://github.com/TomographicImaging/CIL/pull/1481