### PR TITLE
docker: fix `mamba` install

### DIFF
--- a/docker/requirements.yml
+++ b/docker/requirements.yml
@@ -31,6 +31,7 @@ dependencies:
   - ipp-devel
   - ipp-include
   - tigre
+  - pip
   - pip:
     - git+https://github.com/data-exchange/dxchange.git  # CIL
     - git+https://github.com/ismrmrd/ismrmrd-python-tools.git@master#egg=ismrmrd-python-tools

--- a/docker/user_python-ubuntu.sh
+++ b/docker/user_python-ubuntu.sh
@@ -26,16 +26,16 @@ fi
 # Python
 case "$PYTHON" in
 miniconda)
-  # miniconda
-  curl https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh > miniconda.sh
+  #curl -L https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh > miniconda.sh
+  curl -L https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Linux-x86_64.sh > miniconda.sh
   echo -e "\nyes\n${INSTALL_DIR}\nno" | bash miniconda.sh
   rm miniconda.sh
   source "$INSTALL_DIR"/bin/activate
-  conda config --add channels conda-forge
+  #conda config --add channels conda-forge
   # https://github.com/conda/conda/issues/6030
   #conda update -c conda-forge -y conda
-  conda install -c conda-forge -y mamba
-  mamba update -c conda-forge -y setuptools pip
+  # https://github.com/SyneRBI/SIRF-SuperBuild/issues/826
+  #conda install -c conda-forge -c defaults -y mamba
   ;;
 *python*)
   # virtualenv


### PR DESCRIPTION
- fix mamba install (fixes #826)
- suppress missing `pip` dependency warning

https://github.com/bird-house/finch/pull/245 didn't work, but [rtfd](https://mamba.readthedocs.io/en/latest/mamba-installation.html) did :)