### PR TITLE
remove obsolete version restriction for SciPy

### DIFF
--- a/docker/requirements.yml
+++ b/docker/requirements.yml
@@ -11,7 +11,7 @@ dependencies:
   - pytest
   - pytest-cov
   - numpy        # CIL
-  - scipy=1.7.3  # CIL prevents `GLIBCXX_3.4.30' not found
+  - scipy
   - docopt
   - matplotlib
   - Cython       # CIL


### PR DESCRIPTION
temporarily addresses  #834 