### PR TITLE
Bump CIL v23.1.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,8 @@
   - ISMRMRD: v1.13.2
   - SIRF: v3.5.0
   - CIL: 0ba2f8e2935db66ec3dfe8c88e407e8d0eb5609f
+  - CCPi-Regularisation: v22.0.0
+  - TomoPhantom: v2.0.0
   
 ## v3.4.0
 - Removed CIL-ASTRA as it has been merged into CIL code base.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,7 +22,7 @@
   - siemens_to_ismrmrd: 8bb8b08f53ce73c2de9ba5f47f1532f96292d92b
   - ISMRMRD: v1.13.2
   - SIRF: v3.5.0
-  - CIL: 0ba2f8e2935db66ec3dfe8c88e407e8d0eb5609f
+  - CIL: v23.1.0
   - CCPi-Regularisation: v22.0.0
   - TomoPhantom: v2.0.0
   

--- a/SuperBuild/External_CCPi-Regularisation-Toolkit.cmake
+++ b/SuperBuild/External_CCPi-Regularisation-Toolkit.cmake
@@ -98,8 +98,8 @@ if(NOT ( DEFINED "USE_SYSTEM_${externalProjName}" AND "${USE_SYSTEM_${externalPr
 
     set(${proj}_ROOT        ${${proj}_SOURCE_DIR})
     set(${proj}_INCLUDE_DIR ${${proj}_SOURCE_DIR})
-    add_test(NAME CIL_REGULARISATION_TEST_1
-             COMMAND ${PYTHON_EXECUTABLE} -m unittest discover -s test -p test_*.py
+    add_test(NAME CIL_REGULARISATION_TEST_CPU
+             COMMAND ${PYTHON_EXECUTABLE} -m unittest discover -s test -p test_CPU_*.py
     WORKING_DIRECTORY ${${proj}_SOURCE_DIR})
 
   else()

--- a/version_config.cmake
+++ b/version_config.cmake
@@ -148,7 +148,7 @@ set(DEFAULT_JSON_TAG v3.10.4)
 # CCPi CIL
 # minimum supported version of CIL supported is > 22.1.0 or from commit a6062410028c9872c5b355be40b96ed1497fed2a
 set(DEFAULT_CIL_URL https://github.com/TomographicImaging/CIL.git)
-set(DEFAULT_CIL_TAG 0ba2f8e2935db66ec3dfe8c88e407e8d0eb5609f)
+set(DEFAULT_CIL_TAG v23.1.0)
 
 set(DEFAULT_CCPi-Regularisation-Toolkit_URL https://github.com/vais-ral/CCPi-Regularisation-Toolkit.git)
 set(DEFAULT_CCPi-Regularisation-Toolkit_TAG "v22.0.0")

--- a/version_config.cmake
+++ b/version_config.cmake
@@ -124,7 +124,7 @@ set(DEFAULT_astra-toolbox_TAG origin/master)
 
 ## TomoPhantom
 set(DEFAULT_TomoPhantom_URL https://github.com/dkazanc/TomoPhantom )
-set(DEFAULT_TomoPhantom_TAG v1.4)
+set(DEFAULT_TomoPhantom_TAG v2.0.0)
 
 ## NiftyPET
 set(DEFAULT_NiftyPET_URL https://github.com/pjmark/NIPET )
@@ -151,7 +151,7 @@ set(DEFAULT_CIL_URL https://github.com/TomographicImaging/CIL.git)
 set(DEFAULT_CIL_TAG 0ba2f8e2935db66ec3dfe8c88e407e8d0eb5609f)
 
 set(DEFAULT_CCPi-Regularisation-Toolkit_URL https://github.com/vais-ral/CCPi-Regularisation-Toolkit.git)
-set(DEFAULT_CCPi-Regularisation-Toolkit_TAG "v21.0.0")
+set(DEFAULT_CCPi-Regularisation-Toolkit_TAG "v22.0.0")
 
 # CERN ROOT
 set(DEFAULT_ROOT_URL https://github.com/root-project/root)


### PR DESCRIPTION
afaik the plan is:

- merge this PR
- tag & release SIRF v3.5.0 (https://github.com/SyneRBI/SIRF/issues/1198)
- fix #838 (in SIRF)
- tag & release SIRF >=3.5.1