### PR TITLE
re-enable some CIL tests depending on SIRF allocate()

### DIFF
--- a/.github/workflows/test_cil.sh
+++ b/.github/workflows/test_cil.sh
@@ -10,7 +10,7 @@ for fname in test_SIRF.py utils.py testclass.py; do
 done
 
 $SIRF_PATH/../../INSTALL/bin/gadgetron >& ~/gadgetron.log&
-/opt/conda/bin/python -m unittest discover -v ./cil_sirf_test -k GradientPET -k BlockDataContainer
+/opt/conda/bin/python -m unittest discover -v ./cil_sirf_test
 ret=$?
 for i in $(jobs -p); do kill -n 15 $i || : ; done 2>/dev/null  # kill gadgetron
 exit $ret

--- a/.github/workflows/test_cil.sh
+++ b/.github/workflows/test_cil.sh
@@ -5,6 +5,7 @@ set -euxo pipefail
 mkdir cil_sirf_test
 touch cil_sirf_test/__init__.py
 DEFAULT_CIL_TAG=$(python -c 'import cil; print(f"v{cil.version.version}" if cil.version.commit_hash == "-1" else cil.version.commit_hash[1:])' | tail -n1)
+DEFAULT_CIL_TAG=master  # TODO: revert after CIL 24.0.0 release https://github.com/TomographicImaging/CIL/issues/1732
 for fname in test_SIRF.py utils.py testclass.py; do
   curl -fsSL https://raw.githubusercontent.com/TomographicImaging/CIL/$DEFAULT_CIL_TAG/Wrappers/Python/test/$fname > cil_sirf_test/$fname
 done

--- a/.github/workflows/test_cil.sh
+++ b/.github/workflows/test_cil.sh
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
-[ -f .bashrc ] && . .bashrc
+[ -f .bashrc ] && . .bashrc # sets paths to gadgetron & python
 set -euxo pipefail
 
 mkdir cil_sirf_test
 touch cil_sirf_test/__init__.py
-DEFAULT_CIL_TAG=$(/opt/conda/bin/python -c 'import cil; print(f"v{cil.version.version}" if cil.version.commit_hash == "-1" else cil.version.commit_hash[1:])' | tail -n1)
+DEFAULT_CIL_TAG=$(python -c 'import cil; print(f"v{cil.version.version}" if cil.version.commit_hash == "-1" else cil.version.commit_hash[1:])' | tail -n1)
 for fname in test_SIRF.py utils.py testclass.py; do
   curl -fsSL https://raw.githubusercontent.com/TomographicImaging/CIL/$DEFAULT_CIL_TAG/Wrappers/Python/test/$fname > cil_sirf_test/$fname
 done
 
-$SIRF_PATH/../../INSTALL/bin/gadgetron >& ~/gadgetron.log&
-/opt/conda/bin/python -m unittest discover -v ./cil_sirf_test
+gadgetron >& ~/gadgetron.log&
+python -m unittest discover -v ./cil_sirf_test
 ret=$?
 for i in $(jobs -p); do kill -n 15 $i || : ; done 2>/dev/null  # kill gadgetron
 exit $ret

--- a/SuperBuild/External_CIL.cmake
+++ b/SuperBuild/External_CIL.cmake
@@ -96,7 +96,7 @@ if(NOT ( DEFINED "USE_SYSTEM_${externalProjName}" AND "${USE_SYSTEM_${externalPr
            COMMAND ${PYTHON_EXECUTABLE} -m unittest discover -p test_run_*.py
            WORKING_DIRECTORY ${${proj}_SOURCE_DIR}/Wrappers/Python/test)
   add_test(NAME CIL_SIRF_TESTS
-          COMMAND ${PYTHON_EXECUTABLE} -m unittest discover -p test_SIRF*.py -k GradientPET -k BlockDataContainer
+          COMMAND ${PYTHON_EXECUTABLE} -m unittest discover -p test_SIRF*.py
           WORKING_DIRECTORY ${${proj}_SOURCE_DIR}/Wrappers/Python/test)
   add_test(NAME CIL_FRAMEWORK_TESTS_4
            COMMAND ${PYTHON_EXECUTABLE} -m unittest discover -p test_Block_*.py


### PR DESCRIPTION
Now that https://github.com/SyneRBI/SIRF/issues/1212 is fixed, we can reenable relevant tests

Reverts https://github.com/SyneRBI/SIRF-SuperBuild/pull/838/commits/160d5e5ac8396efb29322fe354083a7e5b5d8ad8