### PR TITLE
minor changes in VirtualBox to allow manual specification of CMake version

### DIFF
--- a/VirtualBox/scripts/INSTALL_CMake.sh
+++ b/VirtualBox/scripts/INSTALL_CMake.sh
@@ -3,9 +3,10 @@
 # optional first argument is location (e.g. /usr/local (default), $HOME)
 # If using a system location, execute with sudo
 # You need to make sure the resulting location will be in your path
+# If you want to select the CMake version, set the "ver" environment variable
 
 # Authors: Ben Thomas, Kris Thielemans
-# Copyright 2017-2018 University College London
+# Copyright 2017-2018, 2024 University College London
 
 set -e
 if [ $# -eq 0 ]
@@ -14,15 +15,17 @@ then
 else
     INSTALL_LOC=$1
 fi
-ver=3.21.3
+# default version, but can be set externally
+: ${ver=3.21.3}
 
 echo "Downloading CMake $ver in /tmp"
 cd /tmp
 # next location could be for older releases (although 3.7.2 was in a 3.7 dir, not 3.7.2)
 # wget -c https://cmake.org/files/${ver}/cmake-${ver}-Linux-x86_64.tar.gz
-wget -c https://github.com/Kitware/CMake/releases/download/v${ver}/cmake-${ver}-Linux-x86_64.tar.gz
+wget -c "https://github.com/Kitware/CMake/releases/download/v${ver}/cmake-${ver}-Linux-x86_64.tar.gz"
 
 echo "Installing CMake $ver in ${INSTALL_LOC}"
-cd ${INSTALL_LOC}
-tar xzf /tmp/cmake-${ver}-Linux-x86_64.tar.gz --strip 1
-rm /tmp/cmake-${ver}-Linux-x86_64.tar.gz
+mkdir -p "$INSTALL_LOC"
+cd "$INSTALL_LOC"
+tar xzf "/tmp/cmake-${ver}-Linux-x86_64.tar.gz" --strip 1
+rm "/tmp/cmake-${ver}-Linux-x86_64.tar.gz"


### PR DESCRIPTION
I use this script in other places as well, and it's convenient to be able to specify the CMake version. It also prevents a failure if the location doesn't exist yet. Finally, more quotes means less Codacy issues.

However, we don't test this (until VM creation stage), but it does work.

Not urgent to merge, but a nice to have.