### PR TITLE
default STIR_BUILD_SWIG_PYTHON=ON

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # ChangeLog
 
 ## x.x.x
+- build the STIR native Python interface by default (STIR_BUILD_SWIG_PYTHON=ON). You can still switch this off.
 - updated versions:
   - STIR: v5.2.0
 

--- a/SuperBuild/External_STIR.cmake
+++ b/SuperBuild/External_STIR.cmake
@@ -45,7 +45,7 @@ if(NOT ( DEFINED "USE_SYSTEM_${externalProjName}" AND "${USE_SYSTEM_${externalPr
   set(default_STIR_BUILD_EXECUTABLES OFF)
   RenameVariable(BUILD_STIR_EXECUTABLES STIR_BUILD_EXECUTABLES default_STIR_BUILD_EXECUTABLES)
   option(STIR_BUILD_EXECUTABLES "Build all STIR executables" ${default_STIR_BUILD_EXECUTABLES})
-  set(default_STIR_BUILD_SWIG_PYTHON OFF)
+  set(default_STIR_BUILD_SWIG_PYTHON ON)
   RenameVariable(BUILD_STIR_SWIG_PYTHON STIR_BUILD_SWIG_PYTHON default_STIR_BUILD_SWIG_PYTHON)
   option(STIR_BUILD_SWIG_PYTHON "Build STIR Python interface" ${default_STIR_BUILD_SWIG_PYTHON})
   option(STIR_DISABLE_LLN_MATRIX "Disable STIR Louvain-la-Neuve Matrix library for ECAT7 support" ON)


### PR DESCRIPTION
It's nice to be able to use STIR Python for things that are not in `stir.STIR`, such as examining/manipulating projection data headers.

This PR increases build time a bit, but is otherwise harmless. Would need addition to `CHANGES.md`.

Any objections?