### PR TITLE
Stir 6 prep

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## x.x.x
 - updated versions:
   - STIR: v5.2.0
+  - parallelproj: v1.7.3
 
 ## v3.5.0
 - Temporarily disable CCPi-Regularisation due to #832

--- a/SuperBuild/External_SIRF.cmake
+++ b/SuperBuild/External_SIRF.cmake
@@ -1,7 +1,7 @@
 #========================================================================
 # Author: Benjamin A Thomas
 # Author: Kris Thielemans
-# Copyright 2017, 2020 University College London
+# Copyright 2017, 2020-2024 University College London
 #
 # This file is part of the CCP SyneRBI (formerly PETMR) Synergistic Image Reconstruction Framework (SIRF) SuperBuild.
 #
@@ -38,10 +38,6 @@ if (${BUILD_SPM})
   set(${proj}_DEPENDENCIES "${${proj}_DEPENDENCIES};SPM")
 endif()
 
-message(STATUS "Matlab_ROOT_DIR=" ${Matlab_ROOT_DIR})
-message(STATUS "STIR_DIR=" ${STIR_DIR})
-message(STATUS "NIFTYREG_DIR=" ${NIFTYREG_DIR})
-
 # Include dependent projects if any
 ExternalProject_Include_Dependencies(${proj} DEPENDS_VAR ${proj}_DEPENDENCIES)
 
@@ -71,7 +67,7 @@ if(NOT ( DEFINED "USE_SYSTEM_${externalProjName}" AND "${USE_SYSTEM_${externalPr
   endif()
 
   if (BUILD_SPM)
-    set(extra_args "-DSPM_DIR:PATH=${SPM_DIR}")
+    set(extra_args ${extra_args} "-DSPM_DIR:PATH=${SPM_DIR}")
   endif()
 
   # Sets ${proj}_URL_MODIFIED and ${proj}_TAG_MODIFIED
@@ -85,13 +81,12 @@ if(NOT ( DEFINED "USE_SYSTEM_${externalProjName}" AND "${USE_SYSTEM_${externalPr
     CMAKE_ARGS
       -DCMAKE_PREFIX_PATH:PATH=${SUPERBUILD_INSTALL_DIR}
       -DCMAKE_LIBRARY_PATH:PATH=${SUPERBUILD_INSTALL_DIR}/lib
-      -DCMAKE_INSTALL_PREFIX:PATH=${${proj}_INSTALL_DIR}
       ${Boost_CMAKE_ARGS}
       -DDISABLE_Matlab:BOOL=${DISABLE_Matlab}
       -DMatlab_ROOT_DIR:PATH=${Matlab_ROOT_DIR}
       -DMATLAB_ROOT:PATH=${Matlab_ROOT_DIR} # pass this for compatibility with old SIRF
       -DMATLAB_DEST_DIR:PATH=${MATLAB_DEST_DIR}
-      -DSTIR_DIR:PATH=${STIR_DIR}
+      ${STIR_CMAKE_ARGS}
       ${HDF5_CMAKE_ARGS}
       ${FFTW3_CMAKE_ARGS}
       -DISMRMRD_DIR:PATH=${ISMRMRD_DIR}
@@ -119,7 +114,7 @@ if(NOT ( DEFINED "USE_SYSTEM_${externalProjName}" AND "${USE_SYSTEM_${externalPr
 
    else()
       if(${USE_SYSTEM_${externalProjName}})
-        find_package(${proj} ${${externalProjName}_REQUIRED_VERSION} REQUIRED)
+        find_package(${proj} ${${externalProjName}_REQUIRED_VERSION} REQUIRED CONFIG)
         message(STATUS "USING the system ${externalProjName}, set ${externalProjName}_DIR=${${externalProjName}_DIR}")
    endif()
     ExternalProject_Add_Empty(${proj} DEPENDS "${${proj}_DEPENDENCIES}"

--- a/SuperBuild/External_STIR.cmake
+++ b/SuperBuild/External_STIR.cmake
@@ -1,7 +1,7 @@
 #========================================================================
 # Author: Benjamin A Thomas
 # Author: Kris Thielemans
-# Copyright 2017, 2020 University College London
+# Copyright 2017, 2020-2024 University College London
 #
 # This file is part of the CCP SyneRBI (formerly PETMR) Synergistic Image Reconstruction Framework (SIRF) SuperBuild.
 #
@@ -86,7 +86,7 @@ if(NOT ( DEFINED "USE_SYSTEM_${externalProjName}" AND "${USE_SYSTEM_${externalPr
   # Include dependent projects if any
   ExternalProject_Include_Dependencies(${proj} DEPENDS_VAR ${proj}_DEPENDENCIES)
 
-  set(STIR_CMAKE_ARGS
+  set(STIR_local_extra_cmake_args
     
     -DSWIG_EXECUTABLE:FILEPATH=${SWIG_EXECUTABLE}
     -DBUILD_EXECUTABLES:BOOL=${STIR_BUILD_EXECUTABLES}
@@ -114,29 +114,29 @@ if(NOT ( DEFINED "USE_SYSTEM_${externalProjName}" AND "${USE_SYSTEM_${externalPr
   # 3 choices:
   #     1.  NOT USE_ITK                 <- Disable ITK
   #     2.  USE_ITK &&  USE_SYSTEM_ITK  <- Need to set ITK_DIR, set with find_package in External_ITK.cmake
-  #     3.  USE_ITK && !USE_SYSTEM_ITK  <- No need to do anything (ITK_DIR will get set during the installation of ITK)
+  #     3.  USE_ITK && !USE_SYSTEM_ITK  <- No need to do anything (CMake will find it in CMAKE_INSTALL_PREFIX)
   # STIR enables ITK by default (If it is found, so no need to set -DDISABLE_ITK=OFF for cases 2 and 3)
   if (NOT USE_ITK) 
-    set(STIR_CMAKE_ARGS ${STIR_CMAKE_ARGS} -DDISABLE_ITK:BOOL=ON)
+    set(STIR_local_extra_cmake_args ${STIR_local_extra_cmake_args} -DDISABLE_ITK:BOOL=ON)
   else()
-    set(STIR_CMAKE_ARGS ${STIR_CMAKE_ARGS} -DDISABLE_ITK:BOOL=OFF)
+    set(STIR_local_extra_cmake_args ${STIR_local_extra_cmake_args} -DDISABLE_ITK:BOOL=OFF)
     if (USE_SYSTEM_ITK)
-      set(STIR_CMAKE_ARGS ${STIR_CMAKE_ARGS} -DITK_DIR:PATH=${ITK_DIR})
+      set(STIR_local_extra_cmake_args ${STIR_local_extra_cmake_args} -DITK_DIR:PATH=${ITK_DIR})
     endif()
   endif()
   # same for ROOT
   if (NOT USE_ROOT)
-    set(STIR_CMAKE_ARGS ${STIR_CMAKE_ARGS} -DDISABLE_CERN_ROOT:BOOL=ON)
+    set(STIR_local_extra_cmake_args ${STIR_local_extra_cmake_args} -DDISABLE_CERN_ROOT:BOOL=ON)
   else()
-    set(STIR_CMAKE_ARGS ${STIR_CMAKE_ARGS} -DDISABLE_CERN_ROOT:BOOL=OFF)
+    set(STIR_local_extra_cmake_args ${STIR_local_extra_cmake_args} -DDISABLE_CERN_ROOT:BOOL=OFF)
     if (USE_SYSTEM_ROOT)
-      set(STIR_CMAKE_ARGS ${STIR_CMAKE_ARGS} -DROOT_DIR:PATH=${ROOT_DIR})
+      set(STIR_local_extra_cmake_args ${STIR_local_extra_cmake_args} -DROOT_DIR:PATH=${ROOT_DIR})
     endif()
   endif()
 
   ## If building with NiftyPET projector
   if (${USE_NiftyPET})
-    set(STIR_CMAKE_ARGS ${STIR_CMAKE_ARGS} -DNiftyPET_PATH:PATH=${NiftyPET_PATH})
+    set(STIR_local_extra_cmake_args ${STIR_local_extra_cmake_args} -DNiftyPET_PATH:PATH=${NiftyPET_PATH})
   endif()
 
   # Sets ${proj}_URL_MODIFIED and ${proj}_TAG_MODIFIED
@@ -147,7 +147,7 @@ if(NOT ( DEFINED "USE_SYSTEM_${externalProjName}" AND "${USE_SYSTEM_${externalPr
     ${${proj}_EP_ARGS_GIT}
     ${${proj}_EP_ARGS_DIRS}
     CMAKE_ARGS
-       ${STIR_CMAKE_ARGS}
+       ${STIR_local_extra_cmake_args}
        ${Boost_CMAKE_ARGS}
        ${HDF5_CMAKE_ARGS}
        ${${proj}_EXTRA_CMAKE_ARGS}
@@ -155,7 +155,45 @@ if(NOT ( DEFINED "USE_SYSTEM_${externalProjName}" AND "${USE_SYSTEM_${externalPr
         ${${proj}_DEPENDENCIES}
   )
 
-  set(STIR_DIR       ${SUPERBUILD_INSTALL_DIR}/lib/cmake)
+  ### Handle STIR_DIR
+  # We need to find out where STIRConfig.cmake will be installed, as this changed
+  # in STIR 6.0 (from lib/cmake to lib/cmake/STIR-V.v)
+  # Unfortunately, this is complicated and brittle.
+
+  # Get STIR version to see if it's 5.*
+  # We will download STIR's VERSION.txt and check its content.
+  # Set location of downloaded file
+  set(STIR_VERSION_FILE "${${proj}_BINARY_DIR}/STIR_VERSION.txt")
+  file(REMOVE "${STIR_VERSION_FILE}")
+  # set URL with version file. Sadly this is far too complicated as
+  # STIR_URL could be something weird, and we need to get at the URL for the "raw" file
+  set(STIR_VERSION_URL "${STIR_URL}/${STIR_TAG}/VERSION.txt")
+  string(REPLACE ".git" "" STIR_VERSION_URL "${STIR_VERSION_URL}")
+  string(REPLACE "https://github.com" "https://raw.githubusercontent.com" STIR_VERSION_URL "${STIR_VERSION_URL}")
+  string(REPLACE "git@github.com:" "https://raw.githubusercontent.com/" STIR_VERSION_URL "${STIR_VERSION_URL}")
+  string(REPLACE "origin/" "" STIR_VERSION_URL "${STIR_VERSION_URL}")
+  message(STATUS "Downloading STIR version from ${STIR_VERSION_URL}")
+  # Download and read
+  file(DOWNLOAD "${STIR_VERSION_URL}" "${STIR_VERSION_FILE}" STATUS download_status)
+  list(GET download_status 0 download_status)
+  if (NOT download_status EQUAL 0)
+    message(WARNING
+      "Download failed. We're going to assume this is recent STIR, e.g. where VERSION.txt might be removed.")
+    set (STIR_VERSION 7.0.0)
+  else()
+    file(READ "${STIR_VERSION_FILE}" STIR_VERSION)
+  endif()
+  message(STATUS "Found STIR version ${STIR_VERSION}")
+  # Finally, see what we need to do for different STIR versions
+  if (STIR_VERSION VERSION_LESS 6.0)
+    set(STIR_DIR "${${proj}_INSTALL_DIR}/lib/cmake")
+  else()
+    if (NOT "${proj}_INSTALL_DIR" MATCHES "${STIR_INSTALL_DIR}")
+      message(WARNING "CMake might have trouble finding (the correct) STIR. If so, set STIR_DIR.")
+      # TODO could adapt using the STIR_VERSION above, but it would fail if VERSION.txt is ever removed.
+      # This is a corner case though, so KT is leaving it for later.
+    endif()
+  endif()
 
 
   if (BUILD_TESTING_${proj})
@@ -166,17 +204,14 @@ if(NOT ( DEFINED "USE_SYSTEM_${externalProjName}" AND "${USE_SYSTEM_${externalPr
 
    else()
       if(${USE_SYSTEM_${externalProjName}})
-        find_package(${proj} ${${externalProjName}_REQUIRED_VERSION} REQUIRED)
-        message(STATUS "USING the system ${externalProjName}, set ${externalProjName}_DIR=${${externalProjName}_DIR}")
+        find_package(${proj} ${${externalProjName}_REQUIRED_VERSION} REQUIRED CONFIG)
+        message(STATUS "USING the system ${externalProjName} at ${externalProjName}_DIR=${${externalProjName}_DIR}")
    endif()
     ExternalProject_Add_Empty(${proj} DEPENDS "${${proj}_DEPENDENCIES}"
     ${${proj}_EP_ARGS_DIRS}
    )
   endif()
 
-  mark_as_superbuild(
-    VARS
-      ${externalProjName}_DIR:PATH
-    LABELS
-      "FIND_PACKAGE"
-  )
+  if (STIR_DIR)
+    set(STIR_CMAKE_ARGS "-DSTIR_DIR:PATH=${STIR_DIR}")
+  endif()

--- a/version_config.cmake
+++ b/version_config.cmake
@@ -132,7 +132,7 @@ set(DEFAULT_NiftyPET_TAG 70b97da0a4eea9445e34831f7393947a37bc77e7)
 
 ## parallelproj
 set(DEFAULT_parallelproj_URL https://github.com/gschramm/parallelproj )
-set(DEFAULT_parallelproj_TAG v1.2.13)
+set(DEFAULT_parallelproj_TAG v1.7.3)
 
 ## SIRF-Contribs
 set(DEFAULT_SIRF-Contribs_URL https://github.com/SyneRBI/SIRF-Contribs )
@@ -284,7 +284,7 @@ set(NiftyPET_TAG ${DEFAULT_NiftyPET_TAG} CACHE STRING ON)
 
 set(parallelproj_URL ${DEFAULT_parallelproj_URL} CACHE STRING ON)
 set(parallelproj_TAG ${DEFAULT_parallelproj_TAG} CACHE STRING ON)
-set(parallelproj_REQUIRED_VERSION "1.0")
+set(parallelproj_REQUIRED_VERSION "1.3.4")
 
 set(SIRF-Contribs_URL ${DEFAULT_SIRF-Contribs_URL} CACHE STRING ON)
 set(SIRF-Contribs_TAG ${DEFAULT_SIRF-Contribs_TAG} CACHE STRING ON)


### PR DESCRIPTION
STIR 6.0 (will) put `STIRConfig.cmake` to `lib/cmake/STIR-6.0`. https://github.com/UCL/STIR/pull/1358

Fixes #853 

This PR might fail in `DEVEL_BUILD=ON` until the STIR PR is merged.