### PR TITLE
docker: drop `:jupyter` tag alias

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -46,7 +46,6 @@ jobs:
           type=semver,pattern={{version}}
           type=semver,pattern={{major}}.{{minor}}
           type=semver,pattern={{major}}
-          type=raw,value=jupyter,enable=${{ startsWith(github.ref, 'refs/tags') }}
         labels: |
           org.opencontainers.image.licenses=Apache-2.0${{ matrix.type == 'gpu' && ' AND BSD-3-Clause AND GPL-3.0' || '' }}
     - uses: docker/login-action@v3


### PR DESCRIPTION
Was already undocumented.

Really only existed for debugging purposes.

No longer required after https://github.com/SyneRBI/SIRF-Exercises/pull/221
