### PR TITLE
Update CI to allow failure on `BUILD_ROOT=ON`

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -126,6 +126,7 @@ jobs:
         source ~/virtualenv/bin/activate
         cmake -S ${GITHUB_WORKSPACE} -B ./build ${BUILD_FLAGS} ${EXTRA_BUILD_FLAGS} ${DEVEL_BUILD};
     - name: cmake --build
+      continue-on-error: ${{ contains(matrix.EXTRA_BUILD_FLAGS, '-DUSE_ROOT:BOOL=ON') }} # #899
       run: |
         source ~/virtualenv/bin/activate
         cmake --build ./build -j 2
@@ -141,4 +142,5 @@ jobs:
         path: ${{ github.workspace }}/build/**/*.log
         retention-days: 7
     - name: ctest
+      continue-on-error: ${{ contains(matrix.EXTRA_BUILD_FLAGS, '-DUSE_ROOT:BOOL=ON') }} # #899
       run: ./docker/ctest_sirf.sh

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -126,7 +126,7 @@ jobs:
         source ~/virtualenv/bin/activate
         cmake -S ${GITHUB_WORKSPACE} -B ./build ${BUILD_FLAGS} ${EXTRA_BUILD_FLAGS} ${DEVEL_BUILD};
     - name: cmake --build
-      continue-on-error: ${{ contains(matrix.EXTRA_BUILD_FLAGS, '-DUSE_ROOT:BOOL=ON') }} # #899
+      id: build
       run: |
         source ~/virtualenv/bin/activate
         cmake --build ./build -j 2
@@ -142,5 +142,6 @@ jobs:
         path: ${{ github.workspace }}/build/**/*.log
         retention-days: 7
     - name: ctest
-      continue-on-error: ${{ contains(matrix.EXTRA_BUILD_FLAGS, '-DUSE_ROOT:BOOL=ON') }} # #899
+      # #899
+      if: steps.build.conclusion == 'success'
       run: ./docker/ctest_sirf.sh


### PR DESCRIPTION
- closes #899 

Failures in the build will appear as annotations which can be found at https://github.com/SyneRBI/SIRF-SuperBuild/pull/898/checks or by clicking the checks tab on the PR interface. One needs to spot and click on the little speech balloon with the esclamation mark inside to see the actual errors. 

![image](https://github.com/SyneRBI/SIRF-SuperBuild/assets/14138589/b4ab27b4-f779-47a6-a303-a5637de2d933)


