### PR TITLE
update parallelproj to 1.9.0 (and require it), as well as CIL, SIRF, STIR

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # ChangeLog
 
+## v3.8.0
+- Updated Versions:
+  - parallelproj: 1.9.0 (contains a fix for truncation of the TOF kernel)
+
 ## v3.7.0
 - Adds CCPi-Regularisation-Toolkit as prerequisite for CIL and reinstate unit tests
 - Docker:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@
   - SIRF: 81f5c0a7878ed60577ee526abf8d0cd2b64e334f (20 June 2024)
   - STIR: 12bfa873522653936a4818e9bad9b9da41f11706 (20 June 2024)
   - parallelproj: 1.9.1 (contains a fix for truncation of the TOF kernel)
-  - CIL: 8d111a37cec72756d4b8d80f526ff22333019037 (20 June 2024, numpy 2.0 fix)
+  - CIL: 8449f663bb585c3f5744a7aff78937b6f12d7e20 (21 June 2024)
 
 ## v3.7.0
 - Adds CCPi-Regularisation-Toolkit as prerequisite for CIL and reinstate unit tests

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,10 @@
 
 ## v3.8.0
 - Updated Versions:
-  - parallelproj: 1.9.0 (contains a fix for truncation of the TOF kernel)
+  - SIRF: 81f5c0a7878ed60577ee526abf8d0cd2b64e334f (20 June 2024)
+  - STIR: 12bfa873522653936a4818e9bad9b9da41f11706 (20 June 2024)
+  - parallelproj: 1.9.1 (contains a fix for truncation of the TOF kernel)
+  - CIL: 8d111a37cec72756d4b8d80f526ff22333019037 (20 June 2024, numpy 2.0 fix)
 
 ## v3.7.0
 - Adds CCPi-Regularisation-Toolkit as prerequisite for CIL and reinstate unit tests

--- a/docker/requirements.yml
+++ b/docker/requirements.yml
@@ -17,6 +17,10 @@ dependencies:
   - nibabel
   - deprecation
   - nose
+  - zenodo_get
+  - jupytext
+  - tensorboard
+  - tensorboardx
   - pip
   - cil               # cil
   - ccpi-regulariser  # cil

--- a/version_config.cmake
+++ b/version_config.cmake
@@ -132,16 +132,16 @@ set(DEFAULT_NiftyPET_TAG 70b97da0a4eea9445e34831f7393947a37bc77e7)
 
 ## parallelproj
 set(DEFAULT_parallelproj_URL https://github.com/gschramm/parallelproj)
-set(DEFAULT_parallelproj_TAG v1.9.0)
+set(DEFAULT_parallelproj_TAG v1.9.1)
 
 ## STIR
 set(STIR_REQUIRED_VERSION "6.0.0")
 set(DEFAULT_STIR_URL https://github.com/UCL/STIR)
-set(DEFAULT_STIR_TAG rel_6.1.0)
+set(DEFAULT_STIR_TAG 12bfa873522653936a4818e9bad9b9da41f11706)
 
 ## SIRF
 set(DEFAULT_SIRF_URL https://github.com/SyneRBI/SIRF)
-set(DEFAULT_SIRF_TAG v3.7.0)
+set(DEFAULT_SIRF_TAG 81f5c0a7878ed60577ee526abf8d0cd2b64e334f)
 
 ## pet-rd-tools
 set(DEFAULT_pet_rd_tools_URL https://github.com/UCL/pet-rd-tools)
@@ -161,7 +161,7 @@ set(DEFAULT_JSON_TAG v3.11.3)
 # CCPi CIL
 # minimum supported version of CIL supported is > 22.1.0 or from commit a6062410028c9872c5b355be40b96ed1497fed2a
 set(DEFAULT_CIL_URL https://github.com/TomographicImaging/CIL)
-set(DEFAULT_CIL_TAG ccf17f393ba911d13b74f2327779dde030098fe6) # 28 May 2024
+set(DEFAULT_CIL_TAG 8d111a37cec72756d4b8d80f526ff22333019037) # 20 June 2024 (numpy 2.0 fix)
 
 set(DEFAULT_CCPi-Regularisation-Toolkit_URL https://github.com/TomographicImaging/CCPi-Regularisation-Toolkit)
 set(DEFAULT_CCPi-Regularisation-Toolkit_TAG "v24.0.1")

--- a/version_config.cmake
+++ b/version_config.cmake
@@ -132,7 +132,7 @@ set(DEFAULT_NiftyPET_TAG 70b97da0a4eea9445e34831f7393947a37bc77e7)
 
 ## parallelproj
 set(DEFAULT_parallelproj_URL https://github.com/gschramm/parallelproj)
-set(DEFAULT_parallelproj_TAG v1.7.3)
+set(DEFAULT_parallelproj_TAG v1.9.0)
 
 ## STIR
 set(STIR_REQUIRED_VERSION "6.0.0")
@@ -284,7 +284,7 @@ set(NiftyPET_TAG ${DEFAULT_NiftyPET_TAG} CACHE STRING ON)
 
 set(parallelproj_URL ${DEFAULT_parallelproj_URL} CACHE STRING ON)
 set(parallelproj_TAG ${DEFAULT_parallelproj_TAG} CACHE STRING ON)
-set(parallelproj_REQUIRED_VERSION "1.3.4")
+set(parallelproj_REQUIRED_VERSION "1.9.0") # needed for TOF kernel fix
 
 set(SIRF-Contribs_URL ${DEFAULT_SIRF-Contribs_URL} CACHE STRING ON)
 set(SIRF-Contribs_TAG ${DEFAULT_SIRF-Contribs_TAG} CACHE STRING ON)

--- a/version_config.cmake
+++ b/version_config.cmake
@@ -161,7 +161,7 @@ set(DEFAULT_JSON_TAG v3.11.3)
 # CCPi CIL
 # minimum supported version of CIL supported is > 22.1.0 or from commit a6062410028c9872c5b355be40b96ed1497fed2a
 set(DEFAULT_CIL_URL https://github.com/TomographicImaging/CIL)
-set(DEFAULT_CIL_TAG 8d111a37cec72756d4b8d80f526ff22333019037) # 20 June 2024 (numpy 2.0 fix)
+set(DEFAULT_CIL_TAG 8449f663bb585c3f5744a7aff78937b6f12d7e20) # 21 June 2024
 
 set(DEFAULT_CCPi-Regularisation-Toolkit_URL https://github.com/TomographicImaging/CCPi-Regularisation-Toolkit)
 set(DEFAULT_CCPi-Regularisation-Toolkit_TAG "v24.0.1")


### PR DESCRIPTION
See https://github.com/gschramm/parallelproj/issues/69