### PR TITLE
build cil

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -88,7 +88,7 @@ jobs:
       name: build
       run: |
         # rebuild sirf image
-        ./docker/compose.sh -bR${{ matrix.type == 'gpu' && 'g' || 'c' }}
+        ./docker/compose.sh -bR${{ matrix.type == 'gpu' && 'g' || 'c' }} -- --build-arg BUILD_CIL=ON
         image=synerbi/sirf:latest${{ steps.pull.outputs.suffix }}
         echo "image=$image" >> "$GITHUB_OUTPUT"
         # tag potentially newer core image

--- a/docker/docker-compose.devel.yml
+++ b/docker/docker-compose.devel.yml
@@ -4,18 +4,18 @@ services:
   image: synerbi/jupyter:sirf-build-devel-cpu
   build:
    args:
+    BUILD_CIL: "ON"
     EXTRA_BUILD_FLAGS: >
      -DDEVEL_BUILD=ON
-     -DBUILD_CIL=ON
  sirf:
   container_name: sirf  # for scaling, comment this out https://github.com/docker/compose/issues/3729
   image: synerbi/sirf:devel
   build:
    context: .
    args:
+    BUILD_CIL: "ON"
     EXTRA_BUILD_FLAGS: >
      -DDEVEL_BUILD=ON
-     -DBUILD_CIL=ON
    cache_from: [synerbi/jupyter:sirf-build-devel-cpu]
   cap_add: [SYS_PTRACE]
   security_opt: [seccomp=unconfined]


### PR DESCRIPTION
- fix: trigger `BUILD_CIL` logic in `./docker/compose.sh -d`
- always `BUILD_CIL=ON` for docker `edge,latest,M.m.p` tags (fixes #911)
