### PR TITLE
Update CIL tag to v24.1.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@
   - SIRF: a4d8cae6dd014194642d35e7fb9283e8da44a497 (10 July 2024)
   - STIR: a9b18e0f346759ce81ebc0695d9b571079ab48f0 (9 July 2024)
   - parallelproj: 1.9.1 (contains a fix for truncation of the TOF kernel)
-  - CIL: b3d8ffeeec9413a3b54264e4097a445d2ef5b88b (29 June 2024)
+  - CIL: v24.1.0
 
 ## v3.7.0
 - Adds CCPi-Regularisation-Toolkit as prerequisite for CIL and reinstate unit tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN if test "$BUILD_GPU" != 0; then \
   sed -r -i -e '/^\s*- (cil|ccpi-regulariser).*/d' /opt/scripts/requirements.yml; \
  fi \
  && conda config --env --set channel_priority strict \
- && for ch in defaults ccpi intel conda-forge; do conda config --env --add channels $ch; done \
+ && for ch in defaults ccpi conda-forge; do conda config --env --add channels $ch; done \
  && mamba env update -n base -f /opt/scripts/requirements.yml \
  && mamba clean --all -f -y && fix-permissions "${CONDA_DIR}" /home/${NB_USER}
 

--- a/docker/requirements.yml
+++ b/docker/requirements.yml
@@ -1,7 +1,7 @@
 name: base
 channels:
   - conda-forge
-  - intel # cil
+  - https://software.repos.intel.com/python/conda # cil
   - ccpi  # cil
   - defaults
 dependencies:

--- a/docker/user_demos.sh
+++ b/docker/user_demos.sh
@@ -15,6 +15,8 @@ git clone https://github.com/SyneRBI/SIRF-Exercises --recursive $INSTALL_DIR/SIR
 cd $INSTALL_DIR/SIRF-Exercises
 if [ "$PYTHON" = "miniconda" ]; then
   if [ -f environment.yml ]; then
+    # remove the intel channel
+    sed -r -i -e '/^\s*- (intel).*/d' environment.yml;
     if test "${BUILD_GPU:-0}" != 0; then
       # uncomment GPU deps
       sed -r 's/^(\s*)#\s*(- \S+.*#.*GPU.*)$/\1\2/' environment.yml > environment-sirf.yml

--- a/version_config.cmake
+++ b/version_config.cmake
@@ -161,10 +161,10 @@ set(DEFAULT_JSON_TAG v3.11.3)
 # CCPi CIL
 # minimum supported version of CIL supported is > 22.1.0 or from commit a6062410028c9872c5b355be40b96ed1497fed2a
 set(DEFAULT_CIL_URL https://github.com/TomographicImaging/CIL)
-set(DEFAULT_CIL_TAG b3d8ffeeec9413a3b54264e4097a445d2ef5b88b) # 29 June 2024
+set(DEFAULT_CIL_TAG v24.0.1) # 29 June 2024
 
 set(DEFAULT_CCPi-Regularisation-Toolkit_URL https://github.com/TomographicImaging/CCPi-Regularisation-Toolkit)
-set(DEFAULT_CCPi-Regularisation-Toolkit_TAG "v24.0.1")
+set(DEFAULT_CCPi-Regularisation-Toolkit_TAG "v24.1.0")
 
 # CERN ROOT
 set(DEFAULT_ROOT_URL https://github.com/root-project/root)

--- a/version_config.cmake
+++ b/version_config.cmake
@@ -161,10 +161,10 @@ set(DEFAULT_JSON_TAG v3.11.3)
 # CCPi CIL
 # minimum supported version of CIL supported is > 22.1.0 or from commit a6062410028c9872c5b355be40b96ed1497fed2a
 set(DEFAULT_CIL_URL https://github.com/TomographicImaging/CIL)
-set(DEFAULT_CIL_TAG v24.0.1) # 29 June 2024
+set(DEFAULT_CIL_TAG v24.1.0)
 
 set(DEFAULT_CCPi-Regularisation-Toolkit_URL https://github.com/TomographicImaging/CCPi-Regularisation-Toolkit)
-set(DEFAULT_CCPi-Regularisation-Toolkit_TAG "v24.1.0")
+set(DEFAULT_CCPi-Regularisation-Toolkit_TAG "v24.0.1")
 
 # CERN ROOT
 set(DEFAULT_ROOT_URL https://github.com/root-project/root)


### PR DESCRIPTION
Updates CIL to latest 
- [release v24.1.0 ](https://github.com/TomographicImaging/CIL/releases/tag/v24.1.0)
- Updates the anaconda.org `intel` channel to the new self hosted https://software.repos.intel.com/python/conda
