### PR TITLE
bump CIL version to one with SAG/SAGA SVRG/LSVRG

### DIFF
--- a/version_config.cmake
+++ b/version_config.cmake
@@ -161,7 +161,7 @@ set(DEFAULT_JSON_TAG v3.11.3)
 # CCPi CIL
 # minimum supported version of CIL supported is > 22.1.0 or from commit a6062410028c9872c5b355be40b96ed1497fed2a
 set(DEFAULT_CIL_URL https://github.com/TomographicImaging/CIL)
-set(DEFAULT_CIL_TAG v24.1.0)
+set(DEFAULT_CIL_TAG 4f6e3cfb0648d08071974eba35c1369a892d4924) # 23/08/24
 
 set(DEFAULT_CCPi-Regularisation-Toolkit_URL https://github.com/TomographicImaging/CCPi-Regularisation-Toolkit)
 set(DEFAULT_CCPi-Regularisation-Toolkit_TAG "v24.0.1")


### PR DESCRIPTION
Updates the CIL version to a commit where all the stochastic estiomators (functions) developed during the stochastic hackathon have been merged:
- SGD ([v24.0.0](https://github.com/TomographicImaging/CIL/releases/tag/v24.0.0))
- SAG/SAGA https://github.com/TomographicImaging/CIL/pull/1624
- SVRG/LSVRG https://github.com/TomographicImaging/CIL/pull/1625