### PR TITLE
Windows fixes

### DIFF
--- a/CMake/FindFFTW3.cmake
+++ b/CMake/FindFFTW3.cmake
@@ -80,6 +80,11 @@ if (WIN32)
 
       find_library(${_LIB}_LIBRARY lib${_lib}-3
         HINTS $ENV{FFTW3_ROOT_DIR} PATH_SUFFIXES lib)
+      if (NOT ${_LIB}_LIBRARY)
+        # attempt without lib prefix and -3 suffix (as per conda install for instance)
+        find_library(${_LIB}_LIBRARY ${_lib}
+          HINTS $ENV{FFTW3_ROOT_DIR} PATH_SUFFIXES lib)
+      endif()
       mark_as_advanced(${_LIB}_LIBRARY)
       list(APPEND FFTW3_LIBRARIES ${${_LIB}_LIBRARY})
       list(APPEND _check_list ${_LIB}_LIBRARY)

--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -27,7 +27,10 @@ if (WIN32)
     message(STATUS "CMAKE_GENERATOR: ${CMAKE_GENERATOR}")
     message(STATUS "CMAKE_GENERATOR_PLATFORM: ${CMAKE_GENERATOR_PLATFORM}")
     message(STATUS "CMAKE_VS_PLATFORM_NAME: ${CMAKE_VS_PLATFORM_NAME}")
-    message( FATAL_ERROR "The SuperBuild currently has Win64 hard-wired for dependent libraries. Please use a Win64 generator/toolset. Currently using platform '${CMAKE_VS_PLATFORM_NAME}'.")
+    if (MSVC) # really should check on the generator, but that's more complicated
+      # Issue a warning (as maybe it will work anyway)
+      message(WARNING "The SuperBuild currently has Win64 hard-wired for dependent libraries. Please use a Win64 generator/toolset. Currently using platform '${CMAKE_VS_PLATFORM_NAME}'.")
+     endif()
  endif()
 endif()
 

--- a/SuperBuild/External_CCPi-Regularisation-Toolkit.cmake
+++ b/SuperBuild/External_CCPi-Regularisation-Toolkit.cmake
@@ -55,15 +55,23 @@ if(NOT ( DEFINED "USE_SYSTEM_${externalProjName}" AND "${USE_SYSTEM_${externalPr
     # in case of PYTHONPATH it is sufficient to copy the files to the
     # $PYTHONPATH directory
 
+    # Set CMAKE_CONFIG for use in BUILD_COMMAND etc
+    if (NOT CMAKE_BUILD_TYPE)
+       # default to Release
+       # TODO possibly this could be done via a generator expression to find out how we build.
+       set(CMAKE_CONFIG Release)
+    else()
+       set(CMAKE_CONFIG ${CMAKE_BUILD_TYPE})
+    endif()
     # Sets ${proj}_URL_MODIFIED and ${proj}_TAG_MODIFIED
-
     ExternalProject_Add(${proj}
       ${${proj}_EP_ARGS}
       ${${proj}_EP_ARGS_GIT}
       ${${proj}_EP_ARGS_DIRS}
       # apparently this is the only way to pass environment variables to
       # external projects
-      CONFIGURE_COMMAND ${CMAKE_COMMAND} -E env CIL_VERSION=${${proj}_TAG} ${CMAKE_COMMAND} ${${proj}_SOURCE_DIR}
+      CONFIGURE_COMMAND ${CMAKE_COMMAND} -E env CIL_VERSION=${${proj}_TAG}
+       ${CMAKE_COMMAND}  -G "${CMAKE_GENERATOR}" -S ${${proj}_SOURCE_DIR}
         -DCMAKE_INSTALL_PREFIX:PATH=${${proj}_INSTALL_DIR}
         -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
         -DBUILD_PYTHON_WRAPPER:BOOL=ON
@@ -71,8 +79,8 @@ if(NOT ( DEFINED "USE_SYSTEM_${externalProjName}" AND "${USE_SYSTEM_${externalPr
         ${PYTHONLIBS_CMAKE_ARGS}
         -DPYTHON_DEST_DIR:PATH=${PYTHON_DEST}
 
-      BUILD_COMMAND ${CMAKE_COMMAND} -E env CIL_VERSION=${${proj}_TAG} ${CMAKE_COMMAND} --build .
-      INSTALL_COMMAND ${CMAKE_COMMAND} -E env CIL_VERSION=${${proj}_TAG} ${CMAKE_COMMAND} --build . --target install &&
+      BUILD_COMMAND ${CMAKE_COMMAND} -E env CIL_VERSION=${${proj}_TAG} ${CMAKE_COMMAND} --build . --config ${CMAKE_CONFIG}
+      INSTALL_COMMAND ${CMAKE_COMMAND} -E env CIL_VERSION=${${proj}_TAG} ${CMAKE_COMMAND} --build . --config ${CMAKE_CONFIG} --target install &&
        ${Python_EXECUTABLE} -m pip install ${${proj}_SOURCE_DIR}/src/Python
       #TEST_COMMAND ${Python_EXECUTABLE} -m unittest discover -s ${${proj}_SOURCE_DIR}/test/ -p test*.py
       DEPENDS

--- a/SuperBuild/External_CIL.cmake
+++ b/SuperBuild/External_CIL.cmake
@@ -55,6 +55,16 @@ if(NOT ( DEFINED "USE_SYSTEM_${externalProjName}" AND "${USE_SYSTEM_${externalPr
   if("${PYTHON_STRATEGY}" STREQUAL "PYTHONPATH")
     # in case of PYTHONPATH it is sufficient to copy the files to the
     # $PYTHONPATH directory
+
+    # Set CMAKE_CONFIG for use in BUILD_COMMAND etc
+    if (NOT CMAKE_BUILD_TYPE)
+       # default to Release
+       # TODO possibly this could be done via a generator expression to find out how we build.
+       set(CMAKE_CONFIG Release)
+    else()
+       set(CMAKE_CONFIG ${CMAKE_BUILD_TYPE})
+    endif()
+
     ExternalProject_Add(${proj}
       ${${proj}_EP_ARGS}
       ${${proj}_EP_ARGS_GIT}
@@ -64,14 +74,16 @@ if(NOT ( DEFINED "USE_SYSTEM_${externalProjName}" AND "${USE_SYSTEM_${externalPr
       PATCH_COMMAND ${Python_EXECUTABLE} ${CMAKE_SOURCE_DIR}/patches/cil-patch.py ${${proj}_SOURCE_DIR}/Wrappers/Python/cil/utilities/dataexample.py
       UPDATE_COMMAND ""
       CONFIGURE_COMMAND ${CMAKE_COMMAND} -E env CIL_VERSION=${${proj}_TAG}
-        ${CMAKE_COMMAND} ${${proj}_SOURCE_DIR}
+        ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" -S ${${proj}_SOURCE_DIR}
           -DCMAKE_INSTALL_PREFIX:PATH=${${proj}_INSTALL_DIR}
+          -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
           ${PYTHONLIBS_CMAKE_ARGS}
           -DPYTHON_DEST_DIR:PATH=${PYTHON_DEST}
           -DCIL_VERSION:STRING=${${proj}_TAG}
           ${DIPP_INCLUDE}
           ${DIPP_LIBRARY}
-      INSTALL_COMMAND ${CMAKE_COMMAND} --build . --target install
+      BUILD_COMMAND ${CMAKE_COMMAND} --build . --config ${CMAKE_CONFIG}
+      INSTALL_COMMAND ${CMAKE_COMMAND} --build . --config ${CMAKE_CONFIG}  --target install
         && ${CMAKE_COMMAND} -E copy_directory ${${proj}_SOURCE_DIR}/Wrappers/Python/data ${SUPERBUILD_INSTALL_DIR}/share/cil/
       DEPENDS ${${proj}_DEPENDENCIES}
     )


### PR DESCRIPTION
solve 3 problems:
- conda library name for fftw
- ninja builds don't set `CMAKE_VS_PLATFORM_NAME` which caused our check to crash
- fixes #949 